### PR TITLE
Feature/alerta pppv

### DIFF
--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -166,6 +166,6 @@ class AlertaSession:
             if is_exists_table_alertas:
                 temp_table_df.select(self.COLUMN_ORDER).repartition("dt_partition").write.mode("overwrite").insertInto(table_name, overwrite=True)
             else:
-                temp_table_df.repartition("dt_partition").write.partitionBy("dt_partition").saveAsTable(table_name)
+                temp_table_df.select(self.COLUMN_ORDER).repartition("dt_partition").write.partitionBy("dt_partition").saveAsTable(table_name)
  
             spark.sql("drop table {0}".format(self.temp_table_with_schema))

--- a/src/alertas/main.py
+++ b/src/alertas/main.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     parser.add_argument('-a','--schemaExadataAux', metavar='schemaExadataAux', type=str, help='')
     parser.add_argument('-i','--impalaHost', metavar='impalaHost', type=str, help='')
     parser.add_argument('-o','--impalaPort', metavar='impalaPort', type=str, help='')
-    parser.add_argument('-pl', '--prescricaoLimiar', metavar='prescricaoLimiar', type=int, default=7, help='')
+    parser.add_argument('-pl', '--prescricaoLimiar', metavar='prescricaoLimiar', type=int, default=90, help='')
     args = parser.parse_args()
 
     options = {


### PR DESCRIPTION
Destrincha alerta PPFP em PPFP e PPPV

Também corrige um bug em que a ordem das colunas podia não ser respeitada ao criar a tabela do zero.
Altera o valor default do limiar da prescrição, usado nos alertas PRCR1-4, para refletir a atual regra de negócio (em caso de esquecimento na hora de rodar o processo).