### PR TITLE
Reparticiona em 3 particoes de memoria

### DIFF
--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -173,8 +173,8 @@ class AlertaSession:
             is_exists_table_alertas = self.check_table_exists(self.options['schema_exadata_aux'], self.FINAL_TABLE_NAME)
             table_name = '{0}.{1}'.format(self.options['schema_exadata_aux'], self.FINAL_TABLE_NAME)
             if is_exists_table_alertas:
-                temp_table_df.select(self.COLUMN_ORDER).repartition("dt_partition").write.mode("overwrite").insertInto(table_name, overwrite=True)
+                temp_table_df.select(self.COLUMN_ORDER).repartition(3).write.mode("overwrite").insertInto(table_name, overwrite=True)
             else:
-                temp_table_df.select(self.COLUMN_ORDER).repartition("dt_partition").write.partitionBy("dt_partition").saveAsTable(table_name)
+                temp_table_df.select(self.COLUMN_ORDER).repartition(3).write.partitionBy("dt_partition").saveAsTable(table_name)
  
             spark.sql("drop table {0}".format(self.temp_table_with_schema))


### PR DESCRIPTION
Fazer o repartition por "dt_partition" (para dados que, a cada vez que rodava, só continham um único dt_partition), fazia com que, para cada pasta de partição em disco no HDFS (definido pelo partitionBy), também havia um único arquivo parquet.

Por consequência, as queries no Impala não conseguiam ser paralelizadas, o que tornava o cálculo mais lento do que necessário. Ao fazer o repartition com 3 partições, é possível, no momento das queries no Impala, separar o cálculo pelos 3 nós do cluster.