### PR TITLE
Modificacoes no alerta ic1a para colocar informacoes do overlay

### DIFF
--- a/src/alertas/alerta_ic1a.py
+++ b/src/alertas/alerta_ic1a.py
@@ -12,7 +12,7 @@ columns = [
     col('docu_dk').alias('alrt_docu_dk'), 
     col('docu_nr_mp').alias('alrt_docu_nr_mp'), 
     col('docu_nr_externo').alias('alrt_docu_nr_externo'), 
-    col('docu_tx_etiqueta').alias('alrt_docu_etiqueta'), 
+    col('desc_movimento').alias('alrt_docu_etiqueta'), 
     col('cldc_ds_classe').alias('alrt_docu_classe'),
     col('dt_fim_prazo').alias('alrt_docu_date'),  
     col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
@@ -33,19 +33,29 @@ def alerta_ic1a(options):
         filter('pcao_dt_cancelamento IS NULL')
     sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
         filter('stao_tppr_dk in (6012, 6002, 6511, 6291)')
-   
+    tp_andamento = spark.table('%s.mmps_tp_andamento' % options['schema_exadata_aux'])
+
     doc_apenso = documento.join(apenso, documento.DOCU_DK == apenso.CORR_DOCU_DK2, 'left').\
         filter('corr_tpco_dk is null')
     doc_classe = doc_apenso.join(broadcast(classe), doc_apenso.DOCU_CLDC_DK == classe.cldc_dk, 'left')
     doc_vista = doc_classe.join(vista, doc_classe.DOCU_DK == vista.VIST_DOCU_DK, 'inner')
     doc_andamento = doc_vista.join(andamento, doc_vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
     doc_sub_andamento = doc_andamento.join(sub_andamento, doc_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
+    doc_sub_andamento = doc_sub_andamento.join(tp_andamento, doc_sub_andamento.STAO_TPPR_DK == tp_andamento.ID, 'inner')
     
     doc_eventos = doc_sub_andamento.\
         groupBy(proto_columns).agg({'pcao_dt_andamento': 'max'}).\
         withColumnRenamed('max(pcao_dt_andamento)', 'last_date')
 
-    resultado = doc_eventos.\
+    doc_desc_movimento = doc_eventos.join(
+            doc_sub_andamento.select(['VIST_DOCU_DK', 'PCAO_DT_ANDAMENTO', 'hierarquia']),
+            doc_eventos.docu_dk == doc_sub_andamento.VIST_DOCU_DK
+        ).\
+        filter('last_date = pcao_dt_andamento').\
+        groupBy(proto_columns + ['last_date']).agg({'hierarquia': 'max'}).\
+        withColumnRenamed('max(hierarquia)', 'desc_movimento')
+
+    resultado = doc_desc_movimento.\
         withColumn('dt_fim_prazo', expr("to_timestamp(date_add(last_date, 365), 'yyyy-MM-dd HH:mm:ss')")).\
         withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
         #withColumn('dt_fim_prazo', expr('date_add(last_date, 365)')).\


### PR DESCRIPTION
Coloca informação sobre o movimento mais recente na coluna de alrt_docu_etiqueta do alerta IC1A, para ser usado no overlay.