### PR TITLE
Feature/alerta isps

### DIFF
--- a/src/alertas/alerta_isps.py
+++ b/src/alertas/alerta_isps.py
@@ -1,0 +1,183 @@
+#-*-coding:utf-8-*-
+from pyspark.sql.functions import *
+
+from base import spark
+
+
+columns = [
+    col('docu_dk').alias('alrt_docu_dk'), 
+    col('docu_nr_mp').alias('alrt_docu_nr_mp'), 
+    col('docu_nr_externo').alias('alrt_docu_nr_externo'), 
+    col('docu_tx_etiqueta').alias('alrt_docu_etiqueta'), 
+    col('cldc_ds_classe').alias('alrt_docu_classe'),
+    col('docu_dt_cadastro').alias('alrt_docu_date'),  
+    col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
+    col('cldc_ds_hierarquia').alias('alrt_classe_hierarquia')
+]
+
+indicadores = {
+    'in009': 'Índice de Hidrometação',
+    'in013': 'Índice de Perdas de Faturamento',
+    'in023': 'Índice de Atendimento Urbano de Água',
+    'in049': 'Índice de Perdas na Distribuição',
+    'in015': 'Índice de Coleta de Esgoto',
+    'in016': 'Índice de Tratamento de Esgoto',
+    'in024': 'Índice de Atendimento Urbano de Esgoto Referido',
+    'in046': 'Índice de Esgoto Tratado Referido à Água Consumida',
+    'in020': 'Taxa de Cobertura de Pavimentação e Meio-Fio na Área Urbana do Município',
+    'in021': 'Taxa de Cobertura de Vias Públicas com Redes ou Canais Pluviais Subterrâneos na Área Urbana',
+    'in040': 'Parcela de Domicílios em Situação de Risco de Inundação',
+    'in041': 'Parcela da População Impactada por Eventos Hidrológicos'
+}
+
+def alerta_isps(options):
+    options["schema_opengeo"]
+    options['schema_exadata_aux']
+
+    ano_referencia = spark.sql("""
+            SELECT MAX(ano_referencia) as max_ano
+            FROM {0}.plataforma_amb_saneamento_snis_info_indic_agua
+        """.format(options["schema_opengeo"])
+    )
+    ano_referencia.createOrReplaceTempView('ANO_REFERENCIA')
+
+    agua = spark.sql("""
+        WITH agregados AS (
+            SELECT cod_mun, in009, in013, in023, in049
+            FROM {0}.plataforma_amb_saneamento_snis_info_indic_agua
+            JOIN ANO_REFERENCIA ON ano_referencia = max_ano
+            AND cod_prest IS NULL
+        ),
+        indicadores AS (
+            SELECT A.cod_mun,
+                CASE WHEN A.in009 < R.in009 THEN 'Índice de Hidrometação' ELSE NULL END AS ind1,
+                CASE WHEN A.in013 > R.in013 THEN 'Índice de Perdas de Faturamento' ELSE NULL END AS ind2,
+                CASE WHEN A.in023 < R.in023 THEN 'Índice de Atendimento Urbano de Água' ELSE NULL END AS ind3,
+                CASE WHEN A.in049 > R.in049 THEN 'Índice de Perdas na Distribuição' ELSE NULL END AS ind4
+            FROM agregados A
+            JOIN (SELECT cod_mun, in009, in013, in023, in049 FROM agregados WHERE cod_mun = 33) R ON R.cod_mun != A.cod_mun
+        )
+        SELECT cod_mun, ind1 as alrt_descricao 
+        FROM indicadores
+        WHERE ind1 IS NOT NULL
+        UNION ALL
+        SELECT cod_mun, ind2 as alrt_descricao 
+        FROM indicadores
+        WHERE ind2 IS NOT NULL
+        UNION ALL
+        SELECT cod_mun, ind3 as alrt_descricao 
+        FROM indicadores
+        WHERE ind3 IS NOT NULL
+        UNION ALL
+        SELECT cod_mun, ind4 as alrt_descricao 
+        FROM indicadores
+        WHERE ind4 IS NOT NULL
+    """.format(options["schema_opengeo"]))
+    agua.createOrReplaceTempView('AGUA')
+
+
+    esgoto = spark.sql("""
+        WITH agregados AS (
+            SELECT cod_mun, in015, in016, in024, in046
+            FROM {0}.plataforma_amb_saneamento_snis_info_indic_esgoto
+            JOIN ANO_REFERENCIA ON ano_referencia = max_ano
+            AND cod_prest IS NULL
+        ),
+        indicadores AS (
+            SELECT A.cod_mun,
+                CASE WHEN A.in015 < R.in015 THEN 'Índice de Coleta de Esgoto' ELSE NULL END AS ind1,
+                CASE WHEN A.in016 < R.in016 THEN 'Índice de Tratamento de Esgoto' ELSE NULL END AS ind2,
+                CASE WHEN A.in024 < R.in024 THEN 'Índice de Atendimento Urbano de Esgoto Referido' ELSE NULL END AS ind3,
+                CASE WHEN A.in046 < R.in046 THEN 'Índice de Esgoto Tratado Referido à Água Consumida' ELSE NULL END AS ind4
+            FROM agregados A
+            JOIN (SELECT cod_mun, in015, in016, in024, in046 FROM agregados WHERE cod_mun = 33) R ON R.cod_mun != A.cod_mun
+        )
+        SELECT cod_mun, ind1 as alrt_descricao 
+        FROM indicadores
+        WHERE ind1 IS NOT NULL
+        UNION ALL
+        SELECT cod_mun, ind2 as alrt_descricao 
+        FROM indicadores
+        WHERE ind2 IS NOT NULL
+        UNION ALL
+        SELECT cod_mun, ind3 as alrt_descricao 
+        FROM indicadores
+        WHERE ind3 IS NOT NULL
+        UNION ALL
+        SELECT cod_mun, ind4 as alrt_descricao 
+        FROM indicadores
+        WHERE ind4 IS NOT NULL
+    """.format(options["schema_opengeo"]))
+    esgoto.createOrReplaceTempView('ESGOTO')
+
+    # vermelhos_drenagem = spark.sql("""
+    #     WITH agregados AS (
+    #         SELECT cod_mun, in020, in021, in040, in041
+    #         FROM {0}.plataforma_amb_saneamento_snis_info_indic_drenagem
+    #         JOIN ANO_REFERENCIA ON ano_referencia = max_ano
+    #     ),
+    #     indicadores AS (
+    #         SELECT A.cod_mun,
+    #             CASE WHEN A.in020 < R.in020 THEN 'Taxa de Cobertura de Pavimentação e Meio-Fio na Área Urbana do Município' ELSE false END AS ind1,
+    #             CASE WHEN A.in021 > R.in021 THEN 'Taxa de Cobertura de Vias Públicas com Redes ou Canais Pluviais Subterrâneos na Área Urbana' ELSE false END AS ind2,
+    #             CASE WHEN A.in040 > R.in040 THEN 'Parcela de Domicílios em Situação de Risco de Inundação' ELSE false END AS ind3,
+    #             CASE WHEN A.in041 > R.in041 THEN 'Parcela da População Impactada por Eventos Hidrológicos' ELSE false END AS ind4
+    #         FROM agregados A
+    #         JOIN (SELECT cod_mun, in020, in021, in040, in041 FROM agregados WHERE cod_mun = 33) R ON R.cod_mun != A.cod_mun
+    #     )
+    #     SELECT cod_mun, ind1 as alrt_descricao 
+    #     FROM indicadores
+    #     WHERE ind1 IS NOT NULL
+    #     UNION ALL
+    #     SELECT cod_mun, ind2 as alrt_descricao 
+    #     FROM indicadores
+    #     WHERE ind2 IS NOT NULL
+    #     UNION ALL
+    #     SELECT cod_mun, ind3 as alrt_descricao 
+    #     FROM indicadores
+    #     WHERE ind3 IS NOT NULL
+    #     UNION ALL
+    #     SELECT cod_mun, ind4 as alrt_descricao 
+    #     FROM indicadores
+    #     WHERE ind4 IS NOT NULL
+    # """.format(schema_opengeo))
+
+    INDICADORES = spark.sql("""
+        SELECT * FROM AGUA
+        UNION ALL
+        SELECT * FROM ESGOTO
+        -- UNION ALL
+        -- SELECT * FROM DRENAGEM
+    """)
+    INDICADORES.createOrReplaceTempView('INDICADORES')
+
+    PROMOTORIA_MUNICIPIO = spark.sql("""
+    SELECT
+        stack(14,
+        944468, 330190, -- ITABORAI 
+        400542, 330010, -- ANGRA DOS REIS
+        903670, 330070, -- CABO FRIO
+        400564, 330170, -- DUQUE DE CAXIAS
+        400548, 330455, -- RIO DE JANEIRO
+        400532, 330350, -- NOVA IGUAÇU
+        400562, 330390, -- PETROPOLIS
+        400538, 330330, -- NITEROI
+        400552, 330455, -- RIO DE JANEIRO
+        400553, 330455, -- RIO DE JANEIRO
+        400767, 330580, -- TERESOPOLIS
+        400560, 330455, -- RIO DE JANEIRO
+        1342457, 330020, -- ARARUAMA
+        400652, 330030 -- BARRA DO PIRAI
+    ) AS (id_orgao, cod_mun)
+    """)
+    PROMOTORIA_MUNICIPIO.createOrReplaceTempView("PROMOTORIA_MUNICIPIO")
+
+    resultados = spark.sql("""
+        SELECT P.id_orgao as alrt_orgi_orga_dk, I.alrt_descricao
+        FROM {0}.atualizacao_pj_pacote P
+        JOIN PROMOTORIA_MUNICIPIO M ON M.id_orgao = P.id_orgao
+        JOIN INDICADORES I ON I.cod_mun = M.cod_mun
+        WHERE cod_pct IN (24, 28, 183)
+    """.format(options['schema_exadata_aux']))
+
+    return resultados

--- a/src/alertas/alerta_isps.py
+++ b/src/alertas/alerta_isps.py
@@ -1,39 +1,11 @@
 #-*-coding:utf-8-*-
 from pyspark.sql.functions import *
+from pyspark.sql.types import IntegerType
 
 from base import spark
 
 
-columns = [
-    col('docu_dk').alias('alrt_docu_dk'), 
-    col('docu_nr_mp').alias('alrt_docu_nr_mp'), 
-    col('docu_nr_externo').alias('alrt_docu_nr_externo'), 
-    col('docu_tx_etiqueta').alias('alrt_docu_etiqueta'), 
-    col('cldc_ds_classe').alias('alrt_docu_classe'),
-    col('docu_dt_cadastro').alias('alrt_docu_date'),  
-    col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
-    col('cldc_ds_hierarquia').alias('alrt_classe_hierarquia')
-]
-
-indicadores = {
-    'in009': 'Índice de Hidrometação',
-    'in013': 'Índice de Perdas de Faturamento',
-    'in023': 'Índice de Atendimento Urbano de Água',
-    'in049': 'Índice de Perdas na Distribuição',
-    'in015': 'Índice de Coleta de Esgoto',
-    'in016': 'Índice de Tratamento de Esgoto',
-    'in024': 'Índice de Atendimento Urbano de Esgoto Referido',
-    'in046': 'Índice de Esgoto Tratado Referido à Água Consumida',
-    'in020': 'Taxa de Cobertura de Pavimentação e Meio-Fio na Área Urbana do Município',
-    'in021': 'Taxa de Cobertura de Vias Públicas com Redes ou Canais Pluviais Subterrâneos na Área Urbana',
-    'in040': 'Parcela de Domicílios em Situação de Risco de Inundação',
-    'in041': 'Parcela da População Impactada por Eventos Hidrológicos'
-}
-
 def alerta_isps(options):
-    options["schema_opengeo"]
-    options['schema_exadata_aux']
-
     ano_referencia = spark.sql("""
             SELECT MAX(ano_referencia) as max_ano
             FROM {0}.plataforma_amb_saneamento_snis_info_indic_agua
@@ -41,15 +13,28 @@ def alerta_isps(options):
     )
     ano_referencia.createOrReplaceTempView('ANO_REFERENCIA')
 
+    # Dados de saneamento são liberados a cada ano
+    # Assim, não é necessário calculá-los a cada vez que rodar o alerta
+    try:
+        resultados = spark.sql("""
+            SELECT alrt_orgi_orga_dk, alrt_descricao, alrt_classe_hierarquia
+            FROM {0}.{1}
+            JOIN ANO_REFERENCIA ON ano_referencia = max_ano
+        """.format(options['schema_exadata_aux'], options['isps_tabela_aux']))
+        if resultados.count() > 0:
+            return resultados
+    except:
+        pass
+
     agua = spark.sql("""
         WITH agregados AS (
-            SELECT cod_mun, in009, in013, in023, in049
+            SELECT cod_mun, municipio, in009, in013, in023, in049
             FROM {0}.plataforma_amb_saneamento_snis_info_indic_agua
             JOIN ANO_REFERENCIA ON ano_referencia = max_ano
             AND cod_prest IS NULL
         ),
         indicadores AS (
-            SELECT A.cod_mun,
+            SELECT municipio,
                 CASE WHEN A.in009 < R.in009 THEN 'Índice de Hidrometação' ELSE NULL END AS ind1,
                 CASE WHEN A.in013 > R.in013 THEN 'Índice de Perdas de Faturamento' ELSE NULL END AS ind2,
                 CASE WHEN A.in023 < R.in023 THEN 'Índice de Atendimento Urbano de Água' ELSE NULL END AS ind3,
@@ -57,19 +42,19 @@ def alerta_isps(options):
             FROM agregados A
             JOIN (SELECT cod_mun, in009, in013, in023, in049 FROM agregados WHERE cod_mun = 33) R ON R.cod_mun != A.cod_mun
         )
-        SELECT cod_mun, ind1 as alrt_descricao 
+        SELECT municipio, ind1 as alrt_descricao 
         FROM indicadores
         WHERE ind1 IS NOT NULL
         UNION ALL
-        SELECT cod_mun, ind2 as alrt_descricao 
+        SELECT municipio, ind2 as alrt_descricao 
         FROM indicadores
         WHERE ind2 IS NOT NULL
         UNION ALL
-        SELECT cod_mun, ind3 as alrt_descricao 
+        SELECT municipio, ind3 as alrt_descricao 
         FROM indicadores
         WHERE ind3 IS NOT NULL
         UNION ALL
-        SELECT cod_mun, ind4 as alrt_descricao 
+        SELECT municipio, ind4 as alrt_descricao 
         FROM indicadores
         WHERE ind4 IS NOT NULL
     """.format(options["schema_opengeo"]))
@@ -78,13 +63,13 @@ def alerta_isps(options):
 
     esgoto = spark.sql("""
         WITH agregados AS (
-            SELECT cod_mun, in015, in016, in024, in046
+            SELECT cod_mun, municipio, in015, in016, in024, in046
             FROM {0}.plataforma_amb_saneamento_snis_info_indic_esgoto
             JOIN ANO_REFERENCIA ON ano_referencia = max_ano
             AND cod_prest IS NULL
         ),
         indicadores AS (
-            SELECT A.cod_mun,
+            SELECT municipio,
                 CASE WHEN A.in015 < R.in015 THEN 'Índice de Coleta de Esgoto' ELSE NULL END AS ind1,
                 CASE WHEN A.in016 < R.in016 THEN 'Índice de Tratamento de Esgoto' ELSE NULL END AS ind2,
                 CASE WHEN A.in024 < R.in024 THEN 'Índice de Atendimento Urbano de Esgoto Referido' ELSE NULL END AS ind3,
@@ -92,92 +77,85 @@ def alerta_isps(options):
             FROM agregados A
             JOIN (SELECT cod_mun, in015, in016, in024, in046 FROM agregados WHERE cod_mun = 33) R ON R.cod_mun != A.cod_mun
         )
-        SELECT cod_mun, ind1 as alrt_descricao 
+        SELECT municipio, ind1 as alrt_descricao 
         FROM indicadores
         WHERE ind1 IS NOT NULL
         UNION ALL
-        SELECT cod_mun, ind2 as alrt_descricao 
+        SELECT municipio, ind2 as alrt_descricao 
         FROM indicadores
         WHERE ind2 IS NOT NULL
         UNION ALL
-        SELECT cod_mun, ind3 as alrt_descricao 
+        SELECT municipio, ind3 as alrt_descricao 
         FROM indicadores
         WHERE ind3 IS NOT NULL
         UNION ALL
-        SELECT cod_mun, ind4 as alrt_descricao 
+        SELECT municipio, ind4 as alrt_descricao 
         FROM indicadores
         WHERE ind4 IS NOT NULL
     """.format(options["schema_opengeo"]))
     esgoto.createOrReplaceTempView('ESGOTO')
 
-    # vermelhos_drenagem = spark.sql("""
-    #     WITH agregados AS (
-    #         SELECT cod_mun, in020, in021, in040, in041
-    #         FROM {0}.plataforma_amb_saneamento_snis_info_indic_drenagem
-    #         JOIN ANO_REFERENCIA ON ano_referencia = max_ano
-    #     ),
-    #     indicadores AS (
-    #         SELECT A.cod_mun,
-    #             CASE WHEN A.in020 < R.in020 THEN 'Taxa de Cobertura de Pavimentação e Meio-Fio na Área Urbana do Município' ELSE false END AS ind1,
-    #             CASE WHEN A.in021 > R.in021 THEN 'Taxa de Cobertura de Vias Públicas com Redes ou Canais Pluviais Subterrâneos na Área Urbana' ELSE false END AS ind2,
-    #             CASE WHEN A.in040 > R.in040 THEN 'Parcela de Domicílios em Situação de Risco de Inundação' ELSE false END AS ind3,
-    #             CASE WHEN A.in041 > R.in041 THEN 'Parcela da População Impactada por Eventos Hidrológicos' ELSE false END AS ind4
-    #         FROM agregados A
-    #         JOIN (SELECT cod_mun, in020, in021, in040, in041 FROM agregados WHERE cod_mun = 33) R ON R.cod_mun != A.cod_mun
-    #     )
-    #     SELECT cod_mun, ind1 as alrt_descricao 
-    #     FROM indicadores
-    #     WHERE ind1 IS NOT NULL
-    #     UNION ALL
-    #     SELECT cod_mun, ind2 as alrt_descricao 
-    #     FROM indicadores
-    #     WHERE ind2 IS NOT NULL
-    #     UNION ALL
-    #     SELECT cod_mun, ind3 as alrt_descricao 
-    #     FROM indicadores
-    #     WHERE ind3 IS NOT NULL
-    #     UNION ALL
-    #     SELECT cod_mun, ind4 as alrt_descricao 
-    #     FROM indicadores
-    #     WHERE ind4 IS NOT NULL
-    # """.format(schema_opengeo))
+    # Tabela de drenagem não possui os agregados para o estado diretamente
+    # Assim, é necessário calculá-los a partir dos dados de base
+    drenagem = spark.sql("""
+        WITH agregados AS (
+            SELECT 
+                sum(ri013)/sum(ge008) as in040,
+                ((sum(ri029)+sum(ri067))/sum(ge006)) as in041,
+                sum(ie024)/sum(ie017) as in021,
+                sum(ie019)/sum(ie017) as in020
+            FROM {0}.meio_ambiente_amb_saneamento_snis_drenagem_info_indic_2018
+        ),
+        indicadores AS (
+            SELECT A.municipio,
+                CASE WHEN A.in020 < R.in020 THEN 'Taxa de Cobertura de Pavimentação e Meio-Fio na Área Urbana do Município' ELSE NULL END AS ind1,
+                CASE WHEN A.in021 > R.in021 THEN 'Taxa de Cobertura de Vias Públicas com Redes ou Canais Pluviais Subterrâneos na Área Urbana' ELSE NULL END AS ind2,
+                CASE WHEN A.in040 > R.in040 THEN 'Parcela de Domicílios em Situação de Risco de Inundação' ELSE NULL END AS ind3,
+                CASE WHEN A.in041 > R.in041 THEN 'Parcela da População Impactada por Eventos Hidrológicos' ELSE NULL END AS ind4
+            FROM {0}.plataforma_amb_saneamento_snis_info_indic_drenagem A
+            JOIN agregados R ON 1 = 1
+            JOIN ANO_REFERENCIA ON ano_referencia = max_ano
+        )
+        SELECT municipio, ind1 as alrt_descricao 
+        FROM indicadores
+        WHERE ind1 IS NOT NULL
+        UNION ALL
+        SELECT municipio, ind2 as alrt_descricao 
+        FROM indicadores
+        WHERE ind2 IS NOT NULL
+        UNION ALL
+        SELECT municipio, ind3 as alrt_descricao 
+        FROM indicadores
+        WHERE ind3 IS NOT NULL
+        UNION ALL
+        SELECT municipio, ind4 as alrt_descricao 
+        FROM indicadores
+        WHERE ind4 IS NOT NULL
+    """.format(options["schema_opengeo"]))
+    drenagem.createOrReplaceTempView('DRENAGEM')
 
     INDICADORES = spark.sql("""
         SELECT * FROM AGUA
         UNION ALL
         SELECT * FROM ESGOTO
-        -- UNION ALL
-        -- SELECT * FROM DRENAGEM
+        UNION ALL
+        SELECT * FROM DRENAGEM
     """)
     INDICADORES.createOrReplaceTempView('INDICADORES')
 
-    PROMOTORIA_MUNICIPIO = spark.sql("""
-    SELECT
-        stack(14,
-        944468, 330190, -- ITABORAI 
-        400542, 330010, -- ANGRA DOS REIS
-        903670, 330070, -- CABO FRIO
-        400564, 330170, -- DUQUE DE CAXIAS
-        400548, 330455, -- RIO DE JANEIRO
-        400532, 330350, -- NOVA IGUAÇU
-        400562, 330390, -- PETROPOLIS
-        400538, 330330, -- NITEROI
-        400552, 330455, -- RIO DE JANEIRO
-        400553, 330455, -- RIO DE JANEIRO
-        400767, 330580, -- TERESOPOLIS
-        400560, 330455, -- RIO DE JANEIRO
-        1342457, 330020, -- ARARUAMA
-        400652, 330030 -- BARRA DO PIRAI
-    ) AS (id_orgao, cod_mun)
-    """)
-    PROMOTORIA_MUNICIPIO.createOrReplaceTempView("PROMOTORIA_MUNICIPIO")
-
     resultados = spark.sql("""
-        SELECT P.id_orgao as alrt_orgi_orga_dk, I.alrt_descricao
+        SELECT P.id_orgao as alrt_orgi_orga_dk, I.alrt_descricao, I.municipio as alrt_classe_hierarquia
         FROM {0}.atualizacao_pj_pacote P
-        JOIN PROMOTORIA_MUNICIPIO M ON M.id_orgao = P.id_orgao
-        JOIN INDICADORES I ON I.cod_mun = M.cod_mun
-        WHERE cod_pct IN (24, 28, 183)
-    """.format(options['schema_exadata_aux']))
+        JOIN {1}.institucional_orgaos_meio_ambiente M ON M.cod_orgao = P.id_orgao
+        JOIN INDICADORES I ON I.municipio = M.comarca
+        WHERE cod_pct IN (20, 21, 22, 24, 28, 183)
+    """.format(options['schema_exadata_aux'], options['schema_opengeo']))
+    resultados.createOrReplaceTempView('RESULTADOS_ISPS')
+    spark.catalog.cacheTable("RESULTADOS_ISPS")
+
+    resultados.withColumn('ano_referencia', lit(2018).cast(IntegerType()))\
+        .write.mode('append').saveAsTable('{}.{}'.format(
+            options['schema_exadata_aux'], options['isps_tabela_aux']
+        ))
 
     return resultados

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -37,19 +37,19 @@ class AlertaSession:
         # 'DCTJ': ['Documentos criminais sem retorno do TJ a mais de 60 dias', alerta_dctj],
         # 'DNTJ': ['Documentos não criminais sem retorno do TJ a mais de 120 dias', alerta_dntj],
         # 'DORD': ['Documentos com Órgão Responsável possivelmente desatualizado', alerta_dord],
-        'GATE': ['Documentos com novas ITs do GATE', alerta_gate],
-        'IC1A': ['ICs sem prorrogação por mais de um ano', alerta_ic1a],
-        'MVVD': ['Documentos com vitimas recorrentes recebidos nos ultimos 30 dias', alerta_mvvd],
+        # 'GATE': ['Documentos com novas ITs do GATE', alerta_gate],
+        # 'IC1A': ['ICs sem prorrogação por mais de um ano', alerta_ic1a],
+        # 'MVVD': ['Documentos com vitimas recorrentes recebidos nos ultimos 30 dias', alerta_mvvd],
         # 'OFFP': ['Ofício fora do prazo', alerta_offp],
-        'OUVI': ['Expedientes de Ouvidoria (EO) pendentes de recebimento', alerta_ouvi],
-        'PA1A': ['PAs sem prorrogação por mais de um ano', alerta_pa1a],
-        'PPFP': ['Procedimento Preparatório fora do prazo', alerta_ppfp],
-        'PRCR': ['Processo possivelmente prescrito', alerta_prcr],
-        'VADF': ['Vistas abertas em documentos já fechados', alerta_vadf],
-        'NF30': ['Notícia de Fato a mais de 120 dias', alerta_nf30],
-        'DT2I': ['Movimento em processo de segunda instância', alerta_dt2i],
-        'RO': ['ROs não entregues pelas delegacias', alerta_ro],
-        'ABR1': ['Procedimentos que têm mais de 1 ano para comunicar ao CSMP', alerta_abr1],
+        # 'OUVI': ['Expedientes de Ouvidoria (EO) pendentes de recebimento', alerta_ouvi],
+        # 'PA1A': ['PAs sem prorrogação por mais de um ano', alerta_pa1a],
+        # 'PPFP': ['Procedimento Preparatório fora do prazo', alerta_ppfp],
+        # 'PRCR': ['Processo possivelmente prescrito', alerta_prcr],
+        # 'VADF': ['Vistas abertas em documentos já fechados', alerta_vadf],
+        # 'NF30': ['Notícia de Fato a mais de 120 dias', alerta_nf30],
+        # 'DT2I': ['Movimento em processo de segunda instância', alerta_dt2i],
+        # 'RO': ['ROs não entregues pelas delegacias', alerta_ro],
+        # 'ABR1': ['Procedimentos que têm mais de 1 ano para comunicar ao CSMP', alerta_abr1],
         'ISPS': ['Indicadores de Saneamento em Vermelho', alerta_isps]
     }
     STATUS_RUNNING = "RUNNING"
@@ -60,6 +60,7 @@ class AlertaSession:
     FINAL_TABLE_NAME = "test_mmps_alertas"
     SESSION_TABLE_NAME = "test_mmps_alerta_sessao"
     PRCR_DETALHE_TABLE_NAME = "test_mmps_alerta_detalhe_prcr"
+    ISPS_AUX_TABLE_NAME = "test_mmps_alerta_isps_aux"
 
     # Ordem em que as colunas estão salvas na tabela final
     # Esta ordem deve ser mantida por conta do insertInto que é realizado
@@ -86,6 +87,7 @@ class AlertaSession:
         self.options = options
         # Setando o nome das tabelas de detalhe aqui, podemos centralizá-las como atributos de AlertaSession
         self.options['prescricao_tabela_detalhe'] = self.PRCR_DETALHE_TABLE_NAME
+        self.options['isps_tabela_aux'] = self.ISPS_AUX_TABLE_NAME
         self.session_id = str(uuid.uuid4().int & (1<<60)-1)
         self.start_session = self.now()
         self.end_session = None

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -37,30 +37,30 @@ class AlertaSession:
         # 'DCTJ': ['Documentos criminais sem retorno do TJ a mais de 60 dias', alerta_dctj],
         # 'DNTJ': ['Documentos não criminais sem retorno do TJ a mais de 120 dias', alerta_dntj],
         # 'DORD': ['Documentos com Órgão Responsável possivelmente desatualizado', alerta_dord],
-        # 'GATE': ['Documentos com novas ITs do GATE', alerta_gate],
-        # 'IC1A': ['ICs sem prorrogação por mais de um ano', alerta_ic1a],
-        # 'MVVD': ['Documentos com vitimas recorrentes recebidos nos ultimos 30 dias', alerta_mvvd],
+        'GATE': ['Documentos com novas ITs do GATE', alerta_gate],
+        'IC1A': ['ICs sem prorrogação por mais de um ano', alerta_ic1a],
+        'MVVD': ['Documentos com vitimas recorrentes recebidos nos ultimos 30 dias', alerta_mvvd],
         # 'OFFP': ['Ofício fora do prazo', alerta_offp],
-        # 'OUVI': ['Expedientes de Ouvidoria (EO) pendentes de recebimento', alerta_ouvi],
-        # 'PA1A': ['PAs sem prorrogação por mais de um ano', alerta_pa1a],
-        # 'PPFP': ['Procedimento Preparatório fora do prazo', alerta_ppfp],
-        # 'PRCR': ['Processo possivelmente prescrito', alerta_prcr],
-        # 'VADF': ['Vistas abertas em documentos já fechados', alerta_vadf],
-        # 'NF30': ['Notícia de Fato a mais de 120 dias', alerta_nf30],
-        # 'DT2I': ['Movimento em processo de segunda instância', alerta_dt2i],
-        # 'RO': ['ROs não entregues pelas delegacias', alerta_ro],
-        # 'ABR1': ['Procedimentos que têm mais de 1 ano para comunicar ao CSMP', alerta_abr1],
+        'OUVI': ['Expedientes de Ouvidoria (EO) pendentes de recebimento', alerta_ouvi],
+        'PA1A': ['PAs sem prorrogação por mais de um ano', alerta_pa1a],
+        'PPFP': ['Procedimento Preparatório fora do prazo', alerta_ppfp],
+        'PRCR': ['Processo possivelmente prescrito', alerta_prcr],
+        'VADF': ['Vistas abertas em documentos já fechados', alerta_vadf],
+        'NF30': ['Notícia de Fato a mais de 120 dias', alerta_nf30],
+        'DT2I': ['Movimento em processo de segunda instância', alerta_dt2i],
+        'RO': ['ROs não entregues pelas delegacias', alerta_ro],
+        'ABR1': ['Procedimentos que têm mais de 1 ano para comunicar ao CSMP', alerta_abr1],
         'ISPS': ['Indicadores de Saneamento em Vermelho', alerta_isps]
     }
     STATUS_RUNNING = "RUNNING"
     STATUS_FINISHED = "FINISHED"
     STATUS_ERROR = "ERROR"
 
-    TEMP_TABLE_NAME = "test_temp_mmps_alertas"
-    FINAL_TABLE_NAME = "test_mmps_alertas"
-    SESSION_TABLE_NAME = "test_mmps_alerta_sessao"
-    PRCR_DETALHE_TABLE_NAME = "test_mmps_alerta_detalhe_prcr"
-    ISPS_AUX_TABLE_NAME = "test_mmps_alerta_isps_aux"
+    TEMP_TABLE_NAME = "temp_mmps_alertas"
+    FINAL_TABLE_NAME = "mmps_alertas"
+    SESSION_TABLE_NAME = "mmps_alerta_sessao"
+    PRCR_DETALHE_TABLE_NAME = "mmps_alerta_detalhe_prcr"
+    ISPS_AUX_TABLE_NAME = "mmps_alerta_isps_aux"
 
     # Ordem em que as colunas estão salvas na tabela final
     # Esta ordem deve ser mantida por conta do insertInto que é realizado

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -29,6 +29,7 @@ from alerta_prcr import alerta_prcr
 from alerta_ro import alerta_ro
 from alerta_vadf import alerta_vadf
 from alerta_abr1 import alerta_abr1
+from alerta_isps import alerta_isps
 
 
 class AlertaSession:
@@ -49,15 +50,16 @@ class AlertaSession:
         'DT2I': ['Movimento em processo de segunda instância', alerta_dt2i],
         'RO': ['ROs não entregues pelas delegacias', alerta_ro],
         'ABR1': ['Procedimentos que têm mais de 1 ano para comunicar ao CSMP', alerta_abr1],
+        'ISPS': ['Indicadores de Saneamento em Vermelho', alerta_isps]
     }
     STATUS_RUNNING = "RUNNING"
     STATUS_FINISHED = "FINISHED"
     STATUS_ERROR = "ERROR"
 
-    TEMP_TABLE_NAME = "temp_mmps_alertas"
-    FINAL_TABLE_NAME = "mmps_alertas"
-    SESSION_TABLE_NAME = "mmps_alerta_sessao"
-    PRCR_DETALHE_TABLE_NAME = "mmps_alerta_detalhe_prcr"
+    TEMP_TABLE_NAME = "test_temp_mmps_alertas"
+    FINAL_TABLE_NAME = "test_mmps_alertas"
+    SESSION_TABLE_NAME = "test_mmps_alerta_sessao"
+    PRCR_DETALHE_TABLE_NAME = "test_mmps_alerta_detalhe_prcr"
 
     # Ordem em que as colunas estão salvas na tabela final
     # Esta ordem deve ser mantida por conta do insertInto que é realizado


### PR DESCRIPTION
Alerta ISPS:

Utiliza os campos alrt_descricao, e alrt_classe_hierarquia para descrever o tipo de indicador, e o município em que aquele indicador está vermelho. Como os dados são atualizados anualmente, é utilizada uma tabela para cachear os resultados por ano, de forma a não precisar recalcular a cada vez (o que diminui o custo do alerta para cada vez que rodar).