### PR TITLE
Fix/arquivamento gerencia documento finalizado

### DIFF
--- a/src/alertas/alerta_ic1a.py
+++ b/src/alertas/alerta_ic1a.py
@@ -21,9 +21,8 @@ columns = [
 ]
 
 def alerta_ic1a(options):
-    documento = spark.sql("from documento").\
-        filter('docu_tpst_dk != 11').\
-        filter('docu_fsdc_dk = 1').\
+    documento = spark.sql("from documentos_ativos").\
+        filter('docu_tpst_dk != 3').\
         filter("docu_cldc_dk = 392")
     classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
     apenso = spark.table('%s.mcpr_correlacionamento' % options['schema_exadata']).\

--- a/src/alertas/alerta_nf30.py
+++ b/src/alertas/alerta_nf30.py
@@ -23,9 +23,7 @@ columns = [
 ]
 
 def alerta_nf30(options):
-    documento = spark.sql("from documento").\
-        filter('docu_tpst_dk != 11').\
-        filter('docu_fsdc_dk = 1').\
+    documento = spark.sql("from documentos_ativos").\
         filter('docu_cldc_dk = 393')
     classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
     vista = spark.sql("from vista")

--- a/src/alertas/alerta_pa1a.py
+++ b/src/alertas/alerta_pa1a.py
@@ -23,9 +23,8 @@ proto_columns = [
 ]
 
 def alerta_pa1a(options):
-    documento = spark.sql("from documento").\
-        filter('docu_tpst_dk != 11').\
-        filter('docu_fsdc_dk = 1').\
+    documento = spark.sql("from documentos_ativos").\
+        filter('docu_tpst_dk != 3').\
         filter("""docu_cldc_dk in (
             51105, 51106, 51107, 51108, 51109, 51110, 51111, 51112, 51113, 51114, 51115, 51116, 51117, 
             51118, 51119, 51120, 51121, 51175, 51176, 51177, 51179, 51180, 51181, 51182, 51183, 51216

--- a/src/alertas/alerta_ppfp.py
+++ b/src/alertas/alerta_ppfp.py
@@ -20,9 +20,8 @@ columns = [
 ]
 
 def alerta_ppfp(options):
-    documento = spark.sql("from documento").\
-        filter('docu_tpst_dk != 11').\
-        filter('docu_fsdc_dk = 1').\
+    documento = spark.sql("from documentos_ativos").\
+        filter('docu_tpst_dk != 3').\
         filter('docu_cldc_dk = 395').\
         withColumn('elapsed', lit(datediff(current_date(), 'docu_dt_cadastro')).cast(IntegerType()))
     classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])

--- a/src/alertas/alerta_prcr.py
+++ b/src/alertas/alerta_prcr.py
@@ -38,14 +38,12 @@ def alerta_prcr(options):
             CASE WHEN docu_dt_fato < docu_dt_cadastro THEN docu_dt_fato ELSE docu_dt_cadastro END as docu_dt_fato,
             docu_dt_cadastro, docu_orgi_orga_dk_responsavel, cldc_dk, cldc_ds_classe,
             cldc_ds_hierarquia, id, artigo_lei, max_pena, nome_delito, multiplicador, abuso_menor
-        FROM documento
+        FROM documentos_ativos
         LEFT JOIN {0}.mmps_classe_hierarquia ON cldc_dk = docu_cldc_dk
         JOIN {1}.mcpr_assunto_documento ON docu_dk = asdo_docu_dk
         JOIN {0}.tb_penas_assuntos ON id = asdo_assu_dk
         JOIN {0}.atualizacao_pj_pacote ON docu_orgi_orga_dk_responsavel = id_orgao
-        WHERE docu_tpst_dk != 11
-        AND docu_fsdc_dk = 1
-        AND docu_dt_cadastro >= '2010-01-01'
+        WHERE docu_dt_cadastro >= '2010-01-01'
         AND max_pena IS NOT NULL
         AND cod_pct IN (200, 201, 202, 203, 204, 205, 206, 207, 208, 209)
         AND asdo_dt_fim IS NULL           -- tira assuntos que acabaram

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -145,6 +145,8 @@ class AlertaSession:
             spark.catalog.cacheTable("vista")
             spark.sql("from vista").count()
 
+            # Deixar aqui por enquanto, para corrigir mais rapidamente o bug
+            # Será necessária uma mudança maior de padronização mais à frente
             spark.sql("""
                 SELECT D.*
                 FROM documento D

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -145,6 +145,56 @@ class AlertaSession:
             spark.catalog.cacheTable("vista")
             spark.sql("from vista").count()
 
+            spark.sql("""
+                SELECT D.*
+                FROM documento D
+                LEFT JOIN (
+                    SELECT item_docu_dk
+                    FROM {0}.mcpr_item_movimentacao
+                    JOIN {0}.mcpr_movimentacao ON item_movi_dk = movi_dk
+                    WHERE movi_orga_dk_destino IN (200819, 100500)
+                ) T ON item_docu_dk = docu_dk
+                LEFT JOIN (
+                    SELECT vist_docu_dk, 
+                        CASE
+                        WHEN cod_pct IN (20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 180, 181, 182, 183)
+                            AND stao_tppr_dk IN (
+                                7912, 6548, 6326, 6681, 6678, 6645, 6682, 6680, 6679,
+                                6644, 6668, 6666, 6665, 6669, 6667, 6664, 6655, 6662,
+                                6659, 6658, 6663, 6661, 6660, 6657, 6670, 6676, 6674,
+                                6673, 6677, 6675, 6672, 6018, 6341, 6338, 6019, 6017,
+                                6591, 6339, 6553, 7871, 6343, 6340, 6342, 6021, 6334,
+                                6331, 6022, 6020, 6593, 6332, 7872, 6336, 6333, 6335,
+                                7745, 6346, 6345, 6015, 6016, 6325, 6327, 6328, 6329,
+                                6330, 6337, 6344, 6656, 6671, 7869, 7870, 6324, 7834,
+                                7737, 6350, 6251, 6655, 6326
+                            )
+                            THEN 1
+                        WHEN cod_pct >= 200
+                            AND stao_tppr_dk IN (
+                                6682, 6669, 6018, 6341, 6338, 6019, 6017, 6591, 6339,
+                                7871, 6343, 6340, 6342, 7745, 6346, 7915, 6272, 6253,
+                                6392, 6377, 6378, 6359, 6362, 6361, 6436, 6524, 7737,
+                                7811, 6625, 6718, 7834, 6350
+                            )
+                            THEN 1
+                        ELSE null
+                        END AS is_arquivamento
+                    FROM documento
+                    LEFT JOIN {1}.atualizacao_pj_pacote ON id_orgao = docu_orgi_orga_dk_responsavel
+                    JOIN vista ON vist_docu_dk = docu_dk
+                    JOIN {0}.mcpr_andamento ON vist_dk = pcao_vist_dk
+                    JOIN {0}.mcpr_sub_andamento ON stao_pcao_dk = pcao_dk
+                    JOIN {0}.mcpr_tp_andamento ON tppr_dk = stao_tppr_dk
+                ) A ON vist_docu_dk = docu_dk AND is_arquivamento IS NOT NULL
+                WHERE item_docu_dk IS NULL
+                AND vist_docu_dk IS NULL
+                AND docu_fsdc_dk = 1
+                AND docu_tpst_dk != 11
+            """.format(self.options['schema_exadata'], self.options['schema_exadata_aux'])).createOrReplaceTempView("documentos_ativos")
+            spark.catalog.cacheTable("documentos_ativos")
+            spark.sql("from documentos_ativos").count()
+
             for alerta, (desc, func) in self.alerta_list.items():
                 self.generateAlerta(alerta, desc, func)
             self.write_dataframe()


### PR DESCRIPTION
Cacheia tabela de "documentos_ativos", a ser utilizada pelos alertas. Aqui, o documento ativo é considerado como um documento:
- Em Andamento
- Que não tenha situação "Cancelado"
- Que não tenha tido andamentos de arquivamento
- Que não tenha tido movimento para a Gerência de Arquivo

Para os alertas IC1A, PPFP/PPPV e PA1A, também foram excluídos os documentos que tem situação "Fora da Instituição".