### PR TITLE
Corrige erros na regra de negócio do NF30

### DIFF
--- a/alertas.sh
+++ b/alertas.sh
@@ -4,25 +4,26 @@ spark-submit --master yarn --deploy-mode cluster \
     --keytab "/home/mpmapas/keytab/mpmapas.keytab" \
     --principal mpmapas \
     --queue root.alertas \
-    --num-executors 12 \
+    --num-executors 15 \
     --driver-memory 6g \
     --executor-cores 5 \
     --executor-memory 15g \
     --conf spark.debug.maxToStringFields=2000 \
-    --conf spark.executor.memoryOverhead=6g \
-    --conf spark.driver.memoryOverhead=2g \
+    --conf spark.executor.memoryOverhead=2g \
+    --conf spark.driver.memoryOverhead=1g \
     --conf spark.driver.maxResultSize=5g \
     --conf spark.default.parallelism=100 \
     --conf spark.sql.shuffle.partitions=100 \
     --conf spark.network.timeout=3600 \
-    --conf spark.locality.wait=0 \
+    --conf spark.locality.wait=3s \
     --conf spark.shuffle.file.buffer=1024k \
     --conf spark.io.compression.lz4.blockSize=512k \
     --conf spark.maxRemoteBlockSizeFetchToMem=1500m \
     --conf spark.reducer.maxReqsInFlight=1 \
     --conf spark.shuffle.io.maxRetries=10 \
     --conf spark.shuffle.io.retryWait=60s \
-    --conf "spark.executor.extraJavaOptions=-XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=35" \
+    --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
+    --conf "spark.executor.extraJavaOptions=-XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=32" \
     --py-files src/alertas/*.py,packages/*.egg,packages/*.whl,packages/*.zip src/alertas/main.py $@
 
 while [ $# -gt 0 ]; do
@@ -36,4 +37,3 @@ while [ $# -gt 0 ]; do
 done
 
 impala-shell -q "INVALIDATE METADATA"
-impala-shell -q "COMPUTE STATS ${a}.mmps_alertas"

--- a/src/alertas/alerta_nf30.py
+++ b/src/alertas/alerta_nf30.py
@@ -25,37 +25,84 @@ key_columns = [
 ]
 
 def alerta_nf30(options):
-    documento = spark.sql("from documentos_ativos").\
-        filter('docu_cldc_dk = 393')
-    classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
-    vista = spark.sql("from vista")
-    promotor = spark.table('%s.rh_funcionario' % options['schema_exadata']).\
-        filter('cdtipfunc = 1')
-    andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
-        filter('pcao_dt_cancelamento IS NULL')
-    sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
-        filter('stao_tppr_dk in (6034, 6631, 7751, 7752)')
-    
-    doc_classe = documento.join(broadcast(classe), documento.DOCU_CLDC_DK == classe.cldc_dk, 'left')
-    doc_vista = doc_classe.join(vista, doc_classe.DOCU_DK == vista.VIST_DOCU_DK, 'inner')
-    doc_andamento = doc_vista.join(andamento, doc_vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
-    doc_sub_andamento = doc_andamento.join(sub_andamento, doc_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
-    doc_autuado = doc_sub_andamento.\
-        groupBy(aut_col).agg({'pcao_dt_andamento': 'max'}).\
-        withColumnRenamed('max(pcao_dt_andamento)', 'data_autuacao')
+    # documento = spark.sql("from documentos_ativos").\
+    #     filter('docu_cldc_dk = 393')
+    # vista = spark.sql("from vista")
+    # andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
+    #     filter('pcao_dt_cancelamento IS NULL')
+    # sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
+    #     filter('stao_tppr_dk in (6011, 6012, 6013, 6014, 6251, 6252, 6253, 6259, 6260, 6516, 6533, 6556, 6567, 6628, 6034, 6631, 7751, 7752, 6035, 7754, 7753, 6007, 6632, 6291, 7282, 7283)')
 
-    vista_promotor = vista.join(broadcast(promotor), vista.VIST_PESF_PESS_DK_RESP_ANDAM == promotor.PESF_PESS_DK, 'inner')
-    doc_revisado = doc_autuado.join(vista_promotor, doc_autuado.docu_dk == vista.VIST_DOCU_DK, 'inner').\
-        filter('data_autuacao < vist_dt_abertura_vista').\
-        withColumnRenamed('docu_dk', 'reviewed_docu_dk').select(['reviewed_docu_dk'])
-    
-    doc_nao_revisado = doc_autuado.join(doc_revisado, doc_autuado.docu_dk == doc_revisado.reviewed_docu_dk, 'left').\
-        filter('reviewed_docu_dk IS NULL')
+    # vistas_andamento = vista.join(andamento, vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
+    # vistas_andamento = vistas_andamento.join(sub_andamento, vistas_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
 
-    resultado = doc_nao_revisado.\
-        withColumn('elapsed', lit(datediff(current_date(), 'data_autuacao')).cast(IntegerType())).\
-        filter('elapsed > 120')
+    # conversao = vistas_andamento.filter('stao_tppr_dk in (6011, 6012, 6013, 6014, 6251, 6252, 6253, 6259, 6260, 6322, 6516, 6533, 6556, 6567, 6628)')
+    # autuacao = vistas_andamento.filter('stao_tppr_dk in (6034, 6631, 7751, 7752, 6035, 7754, 7753, 6007, 6632)')
+    # prorrogacao = vistas_andamento.filter('stao_tppr_dk in (6291, 7282, 7283)')
+
+    # docs_sem_conversao = documento.join(conversao, documento.DOCU_DK == conversao.VIST_DOCU_DK, 'left').\
+    #     filter('vist_docu_dk IS NULL').select(aut_col + ['docu_dt_cadastro'])
+
+    # docs_autuacao = docs_sem_conversao.join(autuacao, docs_sem_conversao.docu_dk == autuacao.VIST_DOCU_DK, 'left').\
+    #     withColumn('dt_inicio', when(col('pcao_dt_andamento').isNotNull(), col('pcao_dt_andamento')).otherwise(col('docu_dt_cadastro')))
+    # docs_autuacao = docs_autuacao.\
+    #     groupBy(aut_col).agg({'dt_inicio': 'max'}).\
+    #     withColumnRenamed('max(dt_inicio)', 'data_autuacao')
+
+    # docs_prorrogacao = docs_autuacao.join(prorrogacao, docs_autuacao.docu_dk == prorrogacao.VIST_DOCU_DK, 'left')
+    # docs_com_prorrogacao = docs_prorrogacao.filter('vist_docu_dk is not null')
+    # docs_sem_prorrogacao = docs_prorrogacao.filter('vist_docu_dk is null')
+
+    # resultado_com_prorrogacao = docs_com_prorrogacao.\
+    #     withColumn('elapsed', lit(datediff(current_date(), 'data_autuacao')).cast(IntegerType())).\
+    #     filter('elapsed > 120')
+    # resultado_sem_prorrogacao = docs_sem_prorrogacao.\
+    #     withColumn('elapsed', lit(datediff(current_date(), 'data_autuacao')).cast(IntegerType())).\
+    #     filter('elapsed > 30')
+    # resultado = resultado_com_prorrogacao.union(resultado_sem_prorrogacao)
+
+    ANDAMENTOS_CONVERSAO = (6011, 6012, 6013, 6014, 6251, 6252, 6253, 6259, 6260, 6516, 6533, 6556, 6567, 6628)
+    ANDAMENTOS_PRORROGACAO = (6291, 7282, 7283)
+    ANDAMENTOS_AUTUACAO = (6034, 6631, 7751, 7752, 6035, 7754, 7753, 6007, 6632)
+    ANDAMENTOS_TOTAL = ANDAMENTOS_CONVERSAO + ANDAMENTOS_PRORROGACAO + ANDAMENTOS_AUTUACAO
+
+    resultado = spark.sql("""
+        SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, dt_inicio as data_autuacao, datediff(current_timestamp(), dt_inicio) as elapsed
+        FROM
+        (
+            SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+            CASE WHEN MAX(dt_autuacao) IS NOT NULL THEN MAX(dt_autuacao) ELSE docu_dt_cadastro END AS dt_inicio,
+            MAX(nr_dias_prazo) as nr_dias_prazo
+            FROM 
+            (
+                SELECT docu_dk, docu_nr_mp, docu_dt_cadastro, docu_orgi_orga_dk_responsavel,
+                CASE WHEN stao_tppr_dk IN {ANDAMENTOS_AUTUACAO} THEN pcao_dt_andamento ELSE NULL END as dt_autuacao,
+                CASE WHEN stao_tppr_dk IN {ANDAMENTOS_CONVERSAO} THEN 1 ELSE 0 END as flag_conversao,
+                CASE WHEN stao_tppr_dk IN {ANDAMENTOS_PRORROGACAO} THEN 120 ELSE 30 END AS nr_dias_prazo
+                FROM documentos_ativos
+                LEFT JOIN (
+                    SELECT * FROM
+                    vista
+                    JOIN {schema_exadata}.mcpr_andamento ON pcao_vist_dk = vist_dk
+                    JOIN {schema_exadata}.mcpr_sub_andamento ON stao_pcao_dk = pcao_dk
+                    WHERE pcao_dt_cancelamento IS NULL
+                    AND stao_tppr_dk in {ANDAMENTOS_TOTAL}
+                ) T ON T.vist_docu_dk = docu_dk
+                WHERE docu_cldc_dk = 393
+            ) A
+            GROUP BY docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, docu_dt_cadastro
+            HAVING MAX(flag_conversao) = 0
+        ) B
+        WHERE datediff(current_timestamp(), dt_inicio) > nr_dias_prazo
+    """.format(
+            schema_exadata=options['schema_exadata'],
+            ANDAMENTOS_AUTUACAO=ANDAMENTOS_AUTUACAO,
+            ANDAMENTOS_CONVERSAO=ANDAMENTOS_CONVERSAO,
+            ANDAMENTOS_PRORROGACAO=ANDAMENTOS_PRORROGACAO,
+            ANDAMENTOS_TOTAL=ANDAMENTOS_TOTAL
+        )
+    )
 
     resultado = resultado.withColumn('alrt_key', uuidsha(*key_columns))
 
-    return resultado.select(columns) 
+    return resultado.select(columns)


### PR DESCRIPTION
Antes, buscava-se a autuação (que o documento necessariamente deveria ter para gerar o alerta), e o alerta sumia caso houvesse vista de promotor após. Senão, contava-se 120 dias da data de autuação.

Correções: o fato de haver ou não vista do promotor é irrelevante. Deve-se buscar 3 pontos no documento: autuação, prorrogação, e conversão/instauração de outra classe de documento.
- Caso haja data de autuação, a contagem do prazo começa a partir dela - senão, começa a partir da data de cadastro do documento;
- Caso haja andamento de prorrogação, o prazo a contar é de 120 dias - senão, contam-se 30 dias;
- Caso haja andamento de instauração de algum documento de outra classe (inquérito civil, procedimento preparatório, etc), o alerta sai.

OBS: A correção, inicialmente, foi feita usando a interface RDD padrão do pyspark. No entanto, por algum motivo, o query plan que estava sendo montado fazia cálculos repetidos, não sabendo reaproveitar partes que já haviam sido calculadas (mesmo ao fazer cache, reordenar joins, etc). Assim, optou-se por usar a interface SQL, que funcionou melhor para otimização do query plan.
