### PR TITLE
Fix/bug pa1a

### DIFF
--- a/src/alertas/alerta_abr1.py
+++ b/src/alertas/alerta_abr1.py
@@ -31,6 +31,7 @@ def alerta_abr1(options):
         FROM documentos_ativos
         WHERE datediff(last_day(now()), docu_dt_cadastro) / 365.2425 > 1
             AND docu_dt_cancelamento IS NULL
+            AND docu_cldc_dk IN (51219, 51220, 51221, 51222, 51223, 392, 395)
             AND docu_tpst_dk != 3
             AND (
                 year(current_date()) = 2020 AND month(current_date()) = 11

--- a/src/alertas/alerta_abr1.py
+++ b/src/alertas/alerta_abr1.py
@@ -25,30 +25,33 @@ def alerta_abr1(options):
     else:
         months = "4"
 
-    df = spark.sql("""
-     WITH procedimentos as (
-        SELECT docu_orgi_orga_dk_responsavel
-        FROM documento
-        WHERE docu_cldc_dk IN (51219, 51220, 51221, 51222, 51223, 392, 395)
-            AND datediff(last_day(now()), docu_dt_cadastro) / 365.2425 > 1
+    procedimentos = spark.sql("""
+        SELECT 
+            docu_orgi_orga_dk_responsavel, docu_nr_mp, docu_dt_cadastro, docu_dk
+        FROM documentos_ativos
+        WHERE datediff(last_day(now()), docu_dt_cadastro) / 365.2425 > 1
             AND docu_dt_cancelamento IS NULL
-            AND docu_fsdc_dk = 1
-            AND NOT docu_tpst_dk = 11
+            AND docu_tpst_dk != 3
             AND (
                 year(current_date()) = 2020 AND month(current_date()) = 11
                 OR month(current_date()) IN ({months})
             )
-    )
+    """.format(schema_exadata=options["schema_exadata"], months=months))
+    procedimentos.createOrReplaceTempView("procedimentos")
+
+    df = spark.sql("""
     SELECT
         docu_orgi_orga_dk_responsavel AS id_orgao,
         COUNT(1) AS nr_procedimentos,
         concat_ws('', year(current_date()), month(current_date())) as ano_mes
     FROM procedimentos
     INNER JOIN {schema_aux}.atualizacao_pj_pacote pac ON pac.id_orgao = docu_orgi_orga_dk_responsavel
-	AND UPPER(orgi_nm_orgao) LIKE '%TUTELA%'
+	    AND UPPER(orgi_nm_orgao) LIKE '%TUTELA%'
     GROUP BY docu_orgi_orga_dk_responsavel
-    """.format(schema_aux=options["schema_exadata_aux"], months=months))
+    """.format(schema_aux=options["schema_exadata_aux"]))
 
     df = df.withColumn('alrt_key', uuidsha(*key_columns))
+
+    procedimentos.write.mode("overwrite").saveAsTable("{}.{}".format(options['schema_alertas'], options['abr1_tabela_aux']))
 
     return df.select(columns)

--- a/src/alertas/alerta_ic1a.py
+++ b/src/alertas/alerta_ic1a.py
@@ -15,7 +15,7 @@ columns = [
     col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
     col('elapsed').alias('alrt_dias_referencia'),
     col('alrt_key'),
-    col('stao_dk').alias('alrt_dk_referencia')
+    # col('stao_dk').alias('alrt_dk_referencia')
 ]
 
 key_columns = [
@@ -24,49 +24,95 @@ key_columns = [
 ]
 
 def alerta_ic1a(options):
-    documento = spark.sql("from documentos_ativos").\
-        filter('docu_tpst_dk != 3').\
-        filter("docu_cldc_dk = 392")
-    # classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
-    apenso = spark.table('%s.mcpr_correlacionamento' % options['schema_exadata']).\
-        filter('corr_tpco_dk in (2, 6)')
-    vista = spark.sql("from vista")
-    andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
-        filter('pcao_dt_cancelamento IS NULL')
-    sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
-        filter('stao_tppr_dk in (6012, 6002, 6511, 6291)')
-    orgao_carga = spark.table('%s.orgi_orgao' % options['schema_exadata']).\
-        filter("orgi_nm_orgao LIKE '%GRUPO DE ATUAÇÃO%'")
-    #tp_andamento = spark.table('%s.mmps_tp_andamento' % options['schema_exadata_aux'])
+    # documento = spark.sql("from documentos_ativos").\
+    #     filter('docu_tpst_dk != 3').\
+    #     filter("docu_cldc_dk = 392")
+    # # classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
+    # apenso = spark.table('%s.mcpr_correlacionamento' % options['schema_exadata']).\
+    #     filter('corr_tpco_dk in (2, 6)')
+    # vista = spark.sql("from vista")
+    # andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
+    #     filter('pcao_dt_cancelamento IS NULL')
+    # sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
+    #     filter('stao_tppr_dk in (6012, 6002, 6511, 6291)')
+    # orgao_carga = spark.table('%s.orgi_orgao' % options['schema_exadata']).\
+    #     filter("orgi_nm_orgao LIKE '%GRUPO DE ATUAÇÃO%'")
+    # #tp_andamento = spark.table('%s.mmps_tp_andamento' % options['schema_exadata_aux'])
 
-    doc_apenso = documento.join(apenso, documento.DOCU_DK == apenso.CORR_DOCU_DK2, 'left').\
-        filter('corr_tpco_dk is null')
-    # doc_classe = doc_apenso.join(broadcast(classe), doc_apenso.DOCU_CLDC_DK == classe.cldc_dk, 'left')
-    doc_orgao = doc_apenso.join(broadcast(orgao_carga), doc_apenso.DOCU_ORGI_ORGA_DK_CARGA == orgao_carga.ORGI_DK, 'left').\
-        filter('orgi_dk is null')
-    doc_vista = doc_orgao.join(vista, doc_orgao.DOCU_DK == vista.VIST_DOCU_DK, 'inner')
-    doc_andamento = doc_vista.join(andamento, doc_vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
-    doc_sub_andamento = doc_andamento.join(sub_andamento, doc_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
-    #doc_sub_andamento = doc_sub_andamento.join(tp_andamento, doc_sub_andamento.STAO_TPPR_DK == tp_andamento.ID, 'inner')
+    # doc_apenso = documento.join(apenso, documento.DOCU_DK == apenso.CORR_DOCU_DK2, 'left').\
+    #     filter('corr_tpco_dk is null')
+    # # doc_classe = doc_apenso.join(broadcast(classe), doc_apenso.DOCU_CLDC_DK == classe.cldc_dk, 'left')
+    # doc_orgao = doc_apenso.join(broadcast(orgao_carga), doc_apenso.DOCU_ORGI_ORGA_DK_CARGA == orgao_carga.ORGI_DK, 'left').\
+    #     filter('orgi_dk is null')
+    # doc_vista = doc_orgao.join(vista, doc_orgao.DOCU_DK == vista.VIST_DOCU_DK, 'inner')
+    # doc_andamento = doc_vista.join(andamento, doc_vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
+    # doc_sub_andamento = doc_andamento.join(sub_andamento, doc_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
+    # #doc_sub_andamento = doc_sub_andamento.join(tp_andamento, doc_sub_andamento.STAO_TPPR_DK == tp_andamento.ID, 'inner')
     
-    doc_eventos = doc_sub_andamento.\
-        groupBy(proto_columns).agg({'pcao_dt_andamento': 'max'}).\
-        withColumnRenamed('max(pcao_dt_andamento)', 'last_date')
+    # doc_eventos = doc_sub_andamento.\
+    #     groupBy(proto_columns).agg({'pcao_dt_andamento': 'max'}).\
+    #     withColumnRenamed('max(pcao_dt_andamento)', 'last_date')
 
-    doc_desc_movimento = doc_eventos.join(
-            doc_sub_andamento.select(['VIST_DOCU_DK', 'PCAO_DT_ANDAMENTO', 'STAO_DK']),
-            doc_eventos.docu_dk == doc_sub_andamento.VIST_DOCU_DK
-        ).\
-        filter('last_date = pcao_dt_andamento').\
-        groupBy(proto_columns + ['last_date']).agg({'STAO_DK': 'max'}).\
-        withColumnRenamed('max(STAO_DK)', 'STAO_DK')
+    # doc_desc_movimento = doc_eventos.join(
+    #         doc_sub_andamento.select(['VIST_DOCU_DK', 'PCAO_DT_ANDAMENTO', 'STAO_DK']),
+    #         doc_eventos.docu_dk == doc_sub_andamento.VIST_DOCU_DK
+    #     ).\
+    #     filter('last_date = pcao_dt_andamento').\
+    #     groupBy(proto_columns + ['last_date']).agg({'STAO_DK': 'max'}).\
+    #     withColumnRenamed('max(STAO_DK)', 'STAO_DK')
 
-    resultado = doc_desc_movimento.\
-        withColumn('dt_fim_prazo', expr("to_timestamp(date_add(last_date, 365), 'yyyy-MM-dd HH:mm:ss')")).\
-        withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
-        #withColumn('dt_fim_prazo', expr('date_add(last_date, 365)')).\
+    # resultado = doc_desc_movimento.\
+    #     withColumn('dt_fim_prazo', expr("to_timestamp(date_add(last_date, 365), 'yyyy-MM-dd HH:mm:ss')")).\
+    #     withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
+    #     #withColumn('dt_fim_prazo', expr('date_add(last_date, 365)')).\
 
-    resultado = resultado.filter('elapsed > 0')
+    # resultado = resultado.filter('elapsed > 0')
+
+    ANDAMENTO_PRORROGACAO = 6291
+    ANDAMENTO_INSTAURACAO = (6511, 6012, 6002)
+    ANDAMENTOS_TOTAL = (ANDAMENTO_PRORROGACAO,) + ANDAMENTO_INSTAURACAO
+
+    resultado = spark.sql("""
+        SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+            to_timestamp(date_add(dt_inicio, nr_dias_prazo), 'yyyy-MM-dd HH:mm:ss') as dt_fim_prazo,
+            (datediff(current_timestamp(), dt_inicio) - nr_dias_prazo) as elapsed
+        FROM
+        (
+            SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+            CASE WHEN MAX(dt_instauracao) IS NOT NULL THEN MAX(dt_instauracao) ELSE docu_dt_cadastro END AS dt_inicio,
+            365*(1 + SUM(nr_prorrogacoes)) as nr_dias_prazo
+            FROM 
+            (
+                SELECT docu_dk, docu_nr_mp, docu_dt_cadastro, docu_orgi_orga_dk_responsavel,
+                CASE WHEN stao_tppr_dk IN {ANDAMENTO_INSTAURACAO} THEN pcao_dt_andamento ELSE NULL END as dt_instauracao,
+                CASE WHEN stao_tppr_dk = {ANDAMENTO_PRORROGACAO} THEN 1 ELSE 0 END AS nr_prorrogacoes
+                FROM documentos_ativos
+                LEFT JOIN (SELECT * FROM {schema_exadata}.mcpr_correlacionamento WHERE corr_tpco_dk in (2, 6)) C ON C.corr_docu_dk2 = docu_dk
+                LEFT JOIN (SELECT * FROM {schema_exadata}.orgi_orgao WHERE orgi_nm_orgao LIKE '%GRUPO DE ATUAÇÃO%') O ON O.orgi_dk = docu_orgi_orga_dk_carga
+                LEFT JOIN (
+                    SELECT *
+                    FROM vista
+                    JOIN {schema_exadata}.mcpr_andamento ON pcao_vist_dk = vist_dk
+                    JOIN {schema_exadata}.mcpr_sub_andamento ON stao_pcao_dk = pcao_dk
+                    WHERE pcao_dt_cancelamento IS NULL
+                    AND stao_tppr_dk in {ANDAMENTOS_TOTAL}
+                ) T ON T.vist_docu_dk = docu_dk
+                WHERE docu_cldc_dk = 392
+                AND docu_tpst_dk != 3
+                AND corr_tpco_dk IS NULL
+                AND orgi_dk IS NULL
+            ) A
+            GROUP BY docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, docu_dt_cadastro
+        ) B
+        WHERE datediff(current_timestamp(), dt_inicio) > nr_dias_prazo
+    """.format(
+            schema_exadata=options['schema_exadata'],
+            ANDAMENTO_INSTAURACAO=ANDAMENTO_INSTAURACAO,
+            ANDAMENTO_PRORROGACAO=ANDAMENTO_PRORROGACAO,
+            ANDAMENTOS_TOTAL=ANDAMENTOS_TOTAL
+        )
+    )
+
     resultado = resultado.withColumn('alrt_key', uuidsha(*key_columns))
     
     return resultado.select(columns)

--- a/src/alertas/alerta_ic1a.py
+++ b/src/alertas/alerta_ic1a.py
@@ -15,7 +15,6 @@ columns = [
     col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
     col('elapsed').alias('alrt_dias_referencia'),
     col('alrt_key'),
-    # col('stao_dk').alias('alrt_dk_referencia')
 ]
 
 key_columns = [
@@ -24,68 +23,22 @@ key_columns = [
 ]
 
 def alerta_ic1a(options):
-    # documento = spark.sql("from documentos_ativos").\
-    #     filter('docu_tpst_dk != 3').\
-    #     filter("docu_cldc_dk = 392")
-    # # classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
-    # apenso = spark.table('%s.mcpr_correlacionamento' % options['schema_exadata']).\
-    #     filter('corr_tpco_dk in (2, 6)')
-    # vista = spark.sql("from vista")
-    # andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
-    #     filter('pcao_dt_cancelamento IS NULL')
-    # sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
-    #     filter('stao_tppr_dk in (6012, 6002, 6511, 6291)')
-    # orgao_carga = spark.table('%s.orgi_orgao' % options['schema_exadata']).\
-    #     filter("orgi_nm_orgao LIKE '%GRUPO DE ATUAÇÃO%'")
-    # #tp_andamento = spark.table('%s.mmps_tp_andamento' % options['schema_exadata_aux'])
-
-    # doc_apenso = documento.join(apenso, documento.DOCU_DK == apenso.CORR_DOCU_DK2, 'left').\
-    #     filter('corr_tpco_dk is null')
-    # # doc_classe = doc_apenso.join(broadcast(classe), doc_apenso.DOCU_CLDC_DK == classe.cldc_dk, 'left')
-    # doc_orgao = doc_apenso.join(broadcast(orgao_carga), doc_apenso.DOCU_ORGI_ORGA_DK_CARGA == orgao_carga.ORGI_DK, 'left').\
-    #     filter('orgi_dk is null')
-    # doc_vista = doc_orgao.join(vista, doc_orgao.DOCU_DK == vista.VIST_DOCU_DK, 'inner')
-    # doc_andamento = doc_vista.join(andamento, doc_vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
-    # doc_sub_andamento = doc_andamento.join(sub_andamento, doc_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
-    # #doc_sub_andamento = doc_sub_andamento.join(tp_andamento, doc_sub_andamento.STAO_TPPR_DK == tp_andamento.ID, 'inner')
-    
-    # doc_eventos = doc_sub_andamento.\
-    #     groupBy(proto_columns).agg({'pcao_dt_andamento': 'max'}).\
-    #     withColumnRenamed('max(pcao_dt_andamento)', 'last_date')
-
-    # doc_desc_movimento = doc_eventos.join(
-    #         doc_sub_andamento.select(['VIST_DOCU_DK', 'PCAO_DT_ANDAMENTO', 'STAO_DK']),
-    #         doc_eventos.docu_dk == doc_sub_andamento.VIST_DOCU_DK
-    #     ).\
-    #     filter('last_date = pcao_dt_andamento').\
-    #     groupBy(proto_columns + ['last_date']).agg({'STAO_DK': 'max'}).\
-    #     withColumnRenamed('max(STAO_DK)', 'STAO_DK')
-
-    # resultado = doc_desc_movimento.\
-    #     withColumn('dt_fim_prazo', expr("to_timestamp(date_add(last_date, 365), 'yyyy-MM-dd HH:mm:ss')")).\
-    #     withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
-    #     #withColumn('dt_fim_prazo', expr('date_add(last_date, 365)')).\
-
-    # resultado = resultado.filter('elapsed > 0')
-
     ANDAMENTO_PRORROGACAO = 6291
     ANDAMENTO_INSTAURACAO = (6511, 6012, 6002)
     ANDAMENTOS_TOTAL = (ANDAMENTO_PRORROGACAO,) + ANDAMENTO_INSTAURACAO
+    TAMANHO_PRAZO = 365
 
     resultado = spark.sql("""
         SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
-            to_timestamp(date_add(dt_inicio, nr_dias_prazo), 'yyyy-MM-dd HH:mm:ss') as dt_fim_prazo,
-            (datediff(current_timestamp(), dt_inicio) - nr_dias_prazo) as elapsed
+            to_timestamp(date_add(dt_inicio, {TAMANHO_PRAZO}), 'yyyy-MM-dd HH:mm:ss') as dt_fim_prazo,
+            (datediff(current_timestamp(), dt_inicio) - {TAMANHO_PRAZO}) as elapsed
         FROM
         (
             SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
-            CASE WHEN MAX(dt_instauracao) IS NOT NULL THEN MAX(dt_instauracao) ELSE docu_dt_cadastro END AS dt_inicio,
-            365*(1 + SUM(nr_prorrogacoes)) as nr_dias_prazo
+            CASE WHEN MAX(pcao_dt_andamento) IS NOT NULL THEN MAX(pcao_dt_andamento) ELSE docu_dt_cadastro END AS dt_inicio
             FROM 
             (
-                SELECT docu_dk, docu_nr_mp, docu_dt_cadastro, docu_orgi_orga_dk_responsavel,
-                CASE WHEN stao_tppr_dk IN {ANDAMENTO_INSTAURACAO} THEN pcao_dt_andamento ELSE NULL END as dt_instauracao,
-                CASE WHEN stao_tppr_dk = {ANDAMENTO_PRORROGACAO} THEN 1 ELSE 0 END AS nr_prorrogacoes
+                SELECT docu_dk, docu_nr_mp, docu_dt_cadastro, docu_orgi_orga_dk_responsavel, pcao_dt_andamento
                 FROM documentos_ativos
                 LEFT JOIN (SELECT * FROM {schema_exadata}.mcpr_correlacionamento WHERE corr_tpco_dk in (2, 6)) C ON C.corr_docu_dk2 = docu_dk
                 LEFT JOIN (SELECT * FROM {schema_exadata}.orgi_orgao WHERE orgi_nm_orgao LIKE '%GRUPO DE ATUAÇÃO%') O ON O.orgi_dk = docu_orgi_orga_dk_carga
@@ -104,12 +57,13 @@ def alerta_ic1a(options):
             ) A
             GROUP BY docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, docu_dt_cadastro
         ) B
-        WHERE datediff(current_timestamp(), dt_inicio) > nr_dias_prazo
+        WHERE datediff(current_timestamp(), dt_inicio) > {TAMANHO_PRAZO}
     """.format(
             schema_exadata=options['schema_exadata'],
             ANDAMENTO_INSTAURACAO=ANDAMENTO_INSTAURACAO,
             ANDAMENTO_PRORROGACAO=ANDAMENTO_PRORROGACAO,
-            ANDAMENTOS_TOTAL=ANDAMENTOS_TOTAL
+            ANDAMENTOS_TOTAL=ANDAMENTOS_TOTAL,
+            TAMANHO_PRAZO=TAMANHO_PRAZO
         )
     )
 

--- a/src/alertas/alerta_nf30.py
+++ b/src/alertas/alerta_nf30.py
@@ -25,42 +25,6 @@ key_columns = [
 ]
 
 def alerta_nf30(options):
-    # documento = spark.sql("from documentos_ativos").\
-    #     filter('docu_cldc_dk = 393')
-    # vista = spark.sql("from vista")
-    # andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
-    #     filter('pcao_dt_cancelamento IS NULL')
-    # sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
-    #     filter('stao_tppr_dk in (6011, 6012, 6013, 6014, 6251, 6252, 6253, 6259, 6260, 6516, 6533, 6556, 6567, 6628, 6034, 6631, 7751, 7752, 6035, 7754, 7753, 6007, 6632, 6291, 7282, 7283)')
-
-    # vistas_andamento = vista.join(andamento, vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
-    # vistas_andamento = vistas_andamento.join(sub_andamento, vistas_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
-
-    # conversao = vistas_andamento.filter('stao_tppr_dk in (6011, 6012, 6013, 6014, 6251, 6252, 6253, 6259, 6260, 6322, 6516, 6533, 6556, 6567, 6628)')
-    # autuacao = vistas_andamento.filter('stao_tppr_dk in (6034, 6631, 7751, 7752, 6035, 7754, 7753, 6007, 6632)')
-    # prorrogacao = vistas_andamento.filter('stao_tppr_dk in (6291, 7282, 7283)')
-
-    # docs_sem_conversao = documento.join(conversao, documento.DOCU_DK == conversao.VIST_DOCU_DK, 'left').\
-    #     filter('vist_docu_dk IS NULL').select(aut_col + ['docu_dt_cadastro'])
-
-    # docs_autuacao = docs_sem_conversao.join(autuacao, docs_sem_conversao.docu_dk == autuacao.VIST_DOCU_DK, 'left').\
-    #     withColumn('dt_inicio', when(col('pcao_dt_andamento').isNotNull(), col('pcao_dt_andamento')).otherwise(col('docu_dt_cadastro')))
-    # docs_autuacao = docs_autuacao.\
-    #     groupBy(aut_col).agg({'dt_inicio': 'max'}).\
-    #     withColumnRenamed('max(dt_inicio)', 'data_autuacao')
-
-    # docs_prorrogacao = docs_autuacao.join(prorrogacao, docs_autuacao.docu_dk == prorrogacao.VIST_DOCU_DK, 'left')
-    # docs_com_prorrogacao = docs_prorrogacao.filter('vist_docu_dk is not null')
-    # docs_sem_prorrogacao = docs_prorrogacao.filter('vist_docu_dk is null')
-
-    # resultado_com_prorrogacao = docs_com_prorrogacao.\
-    #     withColumn('elapsed', lit(datediff(current_date(), 'data_autuacao')).cast(IntegerType())).\
-    #     filter('elapsed > 120')
-    # resultado_sem_prorrogacao = docs_sem_prorrogacao.\
-    #     withColumn('elapsed', lit(datediff(current_date(), 'data_autuacao')).cast(IntegerType())).\
-    #     filter('elapsed > 30')
-    # resultado = resultado_com_prorrogacao.union(resultado_sem_prorrogacao)
-
     ANDAMENTOS_CONVERSAO = (6011, 6012, 6013, 6014, 6251, 6252, 6253, 6259, 6260, 6516, 6533, 6556, 6567, 6628)
     ANDAMENTOS_PRORROGACAO = (6291, 7282, 7283)
     ANDAMENTOS_AUTUACAO = (6034, 6631, 7751, 7752, 6035, 7754, 7753, 6007, 6632)
@@ -80,6 +44,7 @@ def alerta_nf30(options):
                 CASE WHEN stao_tppr_dk IN {ANDAMENTOS_CONVERSAO} THEN 1 ELSE 0 END as flag_conversao,
                 CASE WHEN stao_tppr_dk IN {ANDAMENTOS_PRORROGACAO} THEN 120 ELSE 30 END AS nr_dias_prazo
                 FROM documentos_ativos
+                LEFT JOIN (SELECT * FROM {schema_exadata}.mcpr_correlacionamento WHERE corr_tpco_dk in (2, 6)) C ON C.corr_docu_dk2 = docu_dk
                 LEFT JOIN (
                     SELECT * FROM
                     vista
@@ -89,6 +54,7 @@ def alerta_nf30(options):
                     AND stao_tppr_dk in {ANDAMENTOS_TOTAL}
                 ) T ON T.vist_docu_dk = docu_dk
                 WHERE docu_cldc_dk = 393
+                AND corr_tpco_dk IS NULL
             ) A
             GROUP BY docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, docu_dt_cadastro
             HAVING MAX(flag_conversao) = 0

--- a/src/alertas/alerta_pa1a.py
+++ b/src/alertas/alerta_pa1a.py
@@ -16,7 +16,7 @@ columns = [
 ]
 
 proto_columns = [
-    'docu_dk', 'docu_nr_mp', 'docu_orgi_orga_dk_responsavel', 'docu_dt_cadastro'
+    'docu_dk', 'docu_nr_mp', 'docu_orgi_orga_dk_responsavel', 'data_inicio'
 ]
 
 key_columns = [
@@ -25,44 +25,48 @@ key_columns = [
 ]
 
 def alerta_pa1a(options):
-    documento = spark.sql("from documentos_ativos").\
-        filter('docu_tpst_dk != 3').\
-        filter("""docu_cldc_dk in (
-            51105, 51106, 51107, 51108, 51109, 51110, 51111, 51112, 51113, 51114, 51115, 51116, 51117, 
-            51118, 51119, 51120, 51121, 51175, 51176, 51177, 51179, 51180, 51181, 51182, 51183, 51216
-        )""")
-    classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
-    apenso = spark.table('%s.mcpr_correlacionamento' % options['schema_exadata']).\
-        filter('corr_tpco_dk in (2, 6)')
-    vista = spark.sql("from vista")
-    andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
-        filter('pcao_dt_cancelamento IS NULL')
-    sub_andamento = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).\
-        filter('stao_tppr_dk in (6013, 6291)')
-   
-    doc_apenso = documento.join(apenso, documento.DOCU_DK == apenso.CORR_DOCU_DK2, 'left').\
-        filter('corr_tpco_dk is null')
-    doc_classe = doc_apenso.join(broadcast(classe), doc_apenso.DOCU_CLDC_DK == classe.cldc_dk, 'left')
+    ANDAMENTO_PRORROGACAO = 6291
+    ANDAMENTO_INSTAURACAO = 6013
+    ANDAMENTOS_TOTAL = (ANDAMENTO_PRORROGACAO, ANDAMENTO_INSTAURACAO)
 
-    # Previne que vistas que não estão associadas aos andamentos definidos sejam contabilizadas
-    doc_andamento = vista.join(andamento, vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
-    doc_sub_andamento = doc_andamento.join(sub_andamento, doc_andamento.PCAO_DK == sub_andamento.STAO_PCAO_DK, 'inner')
-    doc_totais = doc_classe.join(doc_sub_andamento, doc_classe.DOCU_DK == doc_sub_andamento.VIST_DOCU_DK, 'left')
-
-    # Pode ter mais de um andamento. Pegar o mais recente nesse caso.
-    doc_last_prorrogacao = doc_totais.groupBy(proto_columns).agg({'pcao_dt_andamento': 'max'}).\
-        withColumnRenamed('max(pcao_dt_andamento)', 'pcao_dt_andamento')
-    
-    doc_prorrogado = doc_last_prorrogacao.filter('pcao_dt_andamento is not null').\
-        withColumn('dt_fim_prazo', expr("to_timestamp(date_add(pcao_dt_andamento, 365), 'yyyy-MM-dd HH:mm:ss')")).\
-        withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
-        #withColumn('dt_fim_prazo', expr('date_add(pcao_dt_andamento, 365)')).\
-
-    doc_nao_prorrogado = doc_last_prorrogacao.filter('pcao_dt_andamento is null').\
-        withColumn('dt_fim_prazo', expr('date_add(docu_dt_cadastro, 365)')).\
-        withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
-
-    resultado = doc_prorrogado.union(doc_nao_prorrogado)
+    resultado = spark.sql("""
+        SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+            to_timestamp(date_add(dt_inicio, nr_dias_prazo), 'yyyy-MM-dd HH:mm:ss') as dt_fim_prazo,
+            (datediff(current_timestamp(), dt_inicio) - nr_dias_prazo) as elapsed
+        FROM
+        (
+            SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+            CASE WHEN MAX(dt_instauracao) IS NOT NULL THEN MAX(dt_instauracao) ELSE docu_dt_cadastro END AS dt_inicio,
+            365*(1 + SUM(nr_prorrogacoes)) as nr_dias_prazo
+            FROM 
+            (
+                SELECT docu_dk, docu_nr_mp, docu_dt_cadastro, docu_orgi_orga_dk_responsavel,
+                CASE WHEN stao_tppr_dk = {ANDAMENTO_INSTAURACAO} THEN pcao_dt_andamento ELSE NULL END as dt_instauracao,
+                CASE WHEN stao_tppr_dk = {ANDAMENTO_PRORROGACAO} THEN 1 ELSE 0 END AS nr_prorrogacoes
+                FROM documentos_ativos
+                LEFT JOIN (SELECT * FROM {schema_exadata}.mcpr_correlacionamento WHERE corr_tpco_dk in (2, 6)) C ON C.corr_docu_dk2 = docu_dk
+                LEFT JOIN (
+                    SELECT *
+                    FROM vista
+                    JOIN {schema_exadata}.mcpr_andamento ON pcao_vist_dk = vist_dk
+                    JOIN {schema_exadata}.mcpr_sub_andamento ON stao_pcao_dk = pcao_dk
+                    WHERE pcao_dt_cancelamento IS NULL
+                    AND stao_tppr_dk in {ANDAMENTOS_TOTAL}
+                ) T ON T.vist_docu_dk = docu_dk
+                WHERE docu_cldc_dk IN (51219, 51220, 51221, 51222, 51223)
+                AND docu_tpst_dk != 3
+                AND corr_tpco_dk IS NULL
+            ) A
+            GROUP BY docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, docu_dt_cadastro
+        ) B
+        WHERE datediff(current_timestamp(), dt_inicio) > nr_dias_prazo
+    """.format(
+            schema_exadata=options['schema_exadata'],
+            ANDAMENTO_INSTAURACAO=ANDAMENTO_INSTAURACAO,
+            ANDAMENTO_PRORROGACAO=ANDAMENTO_PRORROGACAO,
+            ANDAMENTOS_TOTAL=ANDAMENTOS_TOTAL
+        )
+    )
 
     resultado = resultado.withColumn('alrt_key', uuidsha(*key_columns))
     

--- a/src/alertas/alerta_ppfp.py
+++ b/src/alertas/alerta_ppfp.py
@@ -13,70 +13,61 @@ columns = [
     col('elapsed').alias('alrt_dias_referencia'),
     col('alrt_sigla'),
     col('alrt_key'),
-    col('stao_dk').alias('alrt_dk_referencia'),
 ]
 
 key_columns = [
     col('docu_dk'),
-    col('stao_dk')  # Um mesmo documento pode ou não ter tido prorrogação
+    col('dt_fim_prazo')
 ]
 
 def alerta_ppfp(options):
-    documento = spark.sql("from documentos_ativos").\
-        filter('docu_tpst_dk != 3').\
-        filter('docu_cldc_dk = 395')
-    classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
-    apenso = spark.table('%s.mcpr_correlacionamento' % options['schema_exadata']).\
-        filter('corr_tpco_dk in (2, 6)')
-    vista = spark.sql("from vista")
-    andamento = spark.table('%s.mcpr_andamento' % options['schema_exadata']).\
-        filter('pcao_dt_cancelamento IS NULL')
-    prorrogacao = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).filter('stao_tppr_dk = 6291')
-    instauracao = spark.table('%s.mcpr_sub_andamento' % options['schema_exadata']).filter('stao_tppr_dk = 6011')
-   
-    # Documento não pode estar apenso ou anexo
-    doc_apenso = documento.join(apenso, documento.DOCU_DK == apenso.CORR_DOCU_DK2, 'left').\
-        filter('corr_tpco_dk is null')
-    doc_classe = doc_apenso.join(broadcast(classe), doc_apenso.DOCU_CLDC_DK == classe.cldc_dk, 'left')
+    ANDAMENTOS_PRORROGACAO = 6291
+    ANDAMENTOS_AUTUACAO = 6011
+    ANDAMENTOS_TOTAL = (ANDAMENTOS_PRORROGACAO, ANDAMENTOS_AUTUACAO)
 
-    doc_andamento = vista.join(andamento, vista.VIST_DK == andamento.PCAO_VIST_DK, 'inner')
-
-    doc_prorrogados = doc_andamento.join(prorrogacao, doc_andamento.PCAO_DK == prorrogacao.STAO_PCAO_DK, 'inner')
-    doc_instauracao = doc_andamento.join(instauracao, doc_andamento.PCAO_DK == instauracao.STAO_PCAO_DK, 'inner')
-
-    doc_totais = doc_classe.join(doc_instauracao, doc_classe.DOCU_DK == doc_instauracao.VIST_DOCU_DK, 'left')
-    # Caso não tenha data de instauração de PP, utilizar data de cadastro
-    doc_data_inicial = doc_totais.\
-        withColumn('docu_dt_cadastro', when(col('pcao_dt_andamento').isNotNull(), col('pcao_dt_andamento')).otherwise(col('docu_dt_cadastro'))).\
-        groupBy(['DOCU_DK', 'DOCU_NR_MP', 'DOCU_ORGI_ORGA_DK_RESPONSAVEL']).agg({'docu_dt_cadastro': 'max'}).\
-        withColumnRenamed('max(docu_dt_cadastro)', 'data_inicio').\
-        withColumn('elapsed', lit(datediff(current_date(), 'data_inicio')).cast(IntegerType()))
-
-    doc_totais = doc_data_inicial.join(doc_prorrogados, doc_data_inicial.DOCU_DK == doc_prorrogados.VIST_DOCU_DK, 'left')
-
-    # Separar em alertas PPFP e PPPV
-    # Documentos fora do prazo (PPFP)
-    # Elapsed = dias desde que o prazo venceu
-    doc_prorrogado = doc_totais.filter('stao_dk is not null').filter('elapsed > 180').\
-        withColumn('elapsed', col('elapsed') - 180)
-    doc_nao_prorrogado = doc_totais.filter('stao_dk is null').filter('elapsed > 90').\
-        withColumn('elapsed', col('elapsed') - 90)
-
-    # Documentos próximos de vencer (PPPV)
-    # Elapsed = dias faltantes para vencer o prazo
-    doc_prorrogado_proximo = doc_totais.filter('stao_dk is not null').filter('elapsed > 160 AND elapsed <= 180').\
-        withColumn('elapsed', 180 - col('elapsed'))
-    doc_nao_prorrogado_proximo = doc_totais.filter('stao_dk is null').filter('elapsed > 70 AND elapsed <= 90').\
-        withColumn('elapsed', 90 - col('elapsed'))
-
-    resultado_ppfp = doc_prorrogado.union(doc_nao_prorrogado).\
-        withColumn('alrt_sigla', lit('PPFP').cast(StringType())).\
-        withColumn('alrt_descricao', lit('Procedimento Preparatório fora do prazo').cast(StringType()))
-    resultado_pppv = doc_prorrogado_proximo.union(doc_nao_prorrogado_proximo).\
-        withColumn('alrt_sigla', lit('PPPV').cast(StringType())).\
-        withColumn('alrt_descricao', lit('Procedimento Preparatório próximo de vencer').cast(StringType()))
-
-    resultado = resultado_ppfp.union(resultado_pppv)
+    resultado = spark.sql("""
+        SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, dt_fim_prazo,
+        CASE WHEN elapsed > nr_dias_prazo THEN 'PPFP' ELSE 'PPPV' END AS alrt_sigla,
+        abs(elapsed - nr_dias_prazo) as elapsed
+        FROM (
+            SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+            to_timestamp(date_add(dt_inicio, nr_dias_prazo), 'yyyy-MM-dd HH:mm:ss') as dt_fim_prazo,
+            datediff(current_timestamp(), dt_inicio) as elapsed, nr_dias_prazo
+            FROM
+            (
+                SELECT docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel,
+                CASE WHEN MAX(dt_instauracao) IS NOT NULL THEN MAX(dt_instauracao) ELSE docu_dt_cadastro END AS dt_inicio,
+                MAX(nr_dias_prazo) as nr_dias_prazo
+                FROM 
+                (
+                    SELECT docu_dk, docu_nr_mp, docu_dt_cadastro, docu_orgi_orga_dk_responsavel,
+                    CASE WHEN stao_tppr_dk = {ANDAMENTOS_AUTUACAO} THEN pcao_dt_andamento ELSE NULL END as dt_instauracao,
+                    CASE WHEN stao_tppr_dk = {ANDAMENTOS_PRORROGACAO} THEN 180 ELSE 90 END AS nr_dias_prazo
+                    FROM documentos_ativos
+                    LEFT JOIN (SELECT * FROM {schema_exadata}.mcpr_correlacionamento WHERE corr_tpco_dk in (2, 6)) C ON C.corr_docu_dk2 = docu_dk
+                    LEFT JOIN (
+                        SELECT * FROM
+                        vista
+                        JOIN {schema_exadata}.mcpr_andamento ON pcao_vist_dk = vist_dk
+                        JOIN {schema_exadata}.mcpr_sub_andamento ON stao_pcao_dk = pcao_dk
+                        WHERE pcao_dt_cancelamento IS NULL
+                        AND stao_tppr_dk IN {ANDAMENTOS_TOTAL}
+                    ) T ON T.vist_docu_dk = docu_dk
+                    WHERE docu_cldc_dk = 395
+                    AND docu_tpst_dk != 3
+                    AND corr_tpco_dk IS NULL
+                ) A
+                GROUP BY docu_dk, docu_nr_mp, docu_orgi_orga_dk_responsavel, docu_dt_cadastro
+            ) B
+            WHERE datediff(current_timestamp(), dt_inicio) > nr_dias_prazo - 20
+        ) C
+    """.format(
+            schema_exadata=options['schema_exadata'],
+            ANDAMENTOS_AUTUACAO=ANDAMENTOS_AUTUACAO,
+            ANDAMENTOS_PRORROGACAO=ANDAMENTOS_PRORROGACAO,
+            ANDAMENTOS_TOTAL=ANDAMENTOS_TOTAL
+        )
+    )
 
     resultado = resultado.withColumn('alrt_key', uuidsha(*key_columns))
     

--- a/src/alertas/alerta_ppfp.py
+++ b/src/alertas/alerta_ppfp.py
@@ -10,6 +10,7 @@ columns = [
     col('docu_dk').alias('alrt_docu_dk'),
     col('docu_nr_mp').alias('alrt_docu_nr_mp'),
     col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
+    col('dt_fim_prazo').alias('alrt_date_referencia'),
     col('elapsed').alias('alrt_dias_referencia'),
     col('alrt_sigla'),
     col('alrt_key'),
@@ -71,4 +72,4 @@ def alerta_ppfp(options):
 
     resultado = resultado.withColumn('alrt_key', uuidsha(*key_columns))
     
-    return resultado.select(columns).distinct()
+    return resultado.select(columns)

--- a/src/alertas/alerta_vadf.py
+++ b/src/alertas/alerta_vadf.py
@@ -9,7 +9,7 @@ from utils import uuidsha
 columns = [
     col('docu_dk').alias('alrt_docu_dk'), 
     col('docu_nr_mp').alias('alrt_docu_nr_mp'), 
-    col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
+    col('vist_orgi_orga_dk').alias('alrt_orgi_orga_dk'),
     col('alrt_key'),
     col('vist_dk').alias('alrt_dk_referencia'),
 ]
@@ -21,12 +21,9 @@ key_columns = [
 
 def alerta_vadf(options):
     documento = spark.sql("from documento")
-    classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux'])
     vista = spark.sql("from vista")
-   
-    doc_classe = documento.join(broadcast(classe), documento.DOCU_CLDC_DK == classe.cldc_dk, 'left')
 
-    resultado = doc_classe.join(vista, vista.VIST_DOCU_DK == doc_classe.DOCU_DK, 'inner').\
+    resultado = documento.join(vista, vista.VIST_DOCU_DK == documento.DOCU_DK, 'inner').\
         filter('docu_fsdc_dk != 1').\
         filter('docu_tpst_dk != 11').\
         filter('vist_dt_fechamento_vista IS NULL')

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -54,6 +54,7 @@ class AlertaSession:
 
     PRCR_DETALHE_TABLE_NAME = "mmps_alerta_detalhe_prcr"
     ISPS_AUX_TABLE_NAME = "mmps_alerta_isps_aux"
+    ABR1_AUX_TABLE_NAME = "mmps_alerta_abr1_aux"
 
     # Ordem em que as colunas estão salvas na tabela final
     # Esta ordem deve ser mantida por conta do insertInto que é realizado
@@ -126,6 +127,7 @@ class AlertaSession:
         # Setando o nome das tabelas de detalhe aqui, podemos centralizá-las como atributos de AlertaSession
         self.options['prescricao_tabela_detalhe'] = self.PRCR_DETALHE_TABLE_NAME
         self.options['isps_tabela_aux'] = self.ISPS_AUX_TABLE_NAME
+        self.options['abr1_tabela_aux'] = self.ABR1_AUX_TABLE_NAME
 
         self.hist_name = lambda x: 'hist_' + x
 


### PR DESCRIPTION
Changelog

ABR1:
Tira documentos que foram à GA, ou que tiveram andamentos finalizadores (via tabela documentos_ativos)
Tira documentos com situação "Fora da Instituição" (tpst_dk != 3)
Salva lista de documentos numa tabela auxiliar (para uso no backend, para simplificar queries e melhor garantia de consistência entre resultados)

IC1A:
Passa pra SQL (aumenta ligeiramente a performance)
Antes, a IC precisava NECESSARIAMENTE ter um andamento de instauração ou prorrogação para ativar o alerta. Agora, se não tiver, usa a data de cadastro do documento.

NF30:
Retira documentos que sejam apenso/anexo em outros documentos.

PA1A:
Passa pra SQL (aumenta ligeiramente a performance)
Muda lista de classes de documentos considerada (agora é a mesma de outros componentes que olham PA)
OBS: Inicialmente, havia se pensado em fazer a contagem sempre a partir da data de cadastro/instauração da PA, e incrementar +1 ano a cada prorrogação.
No entanto, isso levava a casos em que havia uma instauração, e anos depois uma prorrogação, fazendo com que, mesmo com a prorrogação, o documento continuasse fora do prazo.
Por isso, decidiu-se manter a lógica de contagem atual, contando 1 ano a partir da data de instauração/prorrogação mais recente (ou data cadastro quando não houver).

PPFP/PPPV:
Passa pra SQL (aumenta ligeiramente a performance)
Corrige leve bug em que alguns documentos podiam aparecer repetidos.