### PR TITLE
Conserta e reativa alertas DCTJ e DNTJ

### DIFF
--- a/src/alertas/alerta_dctj.py
+++ b/src/alertas/alerta_dctj.py
@@ -2,25 +2,31 @@
 from pyspark.sql.types import IntegerType
 from pyspark.sql.functions import *
 
-
 from base import spark
+from utils import uuidsha
+
 
 columns = [
-    col('docu_dk').alias('alrt_docu_dk'), 
-    col('docu_nr_mp').alias('alrt_docu_nr_mp'), 
-    col('dt_fim_prazo').alias('alrt_date_referencia'),  
+    col('docu_dk').alias('alrt_docu_dk'),
+    col('docu_nr_mp').alias('alrt_docu_nr_mp'),
+    col('dt_guia_tj').alias('alrt_date_referencia'),
     col('docu_orgi_orga_dk_responsavel').alias('alrt_orgi_orga_dk'),
     col('elapsed').alias('alrt_dias_referencia'),
+    col('alrt_key'),
+    col('alrt_sigla')
+]
+
+key_columns = [
+    col('docu_dk'),
+    col('dt_guia_tj')
 ]
 
 pre_columns = [
-    'docu_dk', 'docu_nr_mp', 'docu_orgi_orga_dk_responsavel'
+    'docu_dk', 'docu_nr_mp', 'docu_orgi_orga_dk_responsavel',
 ]
 
 def alerta_dctj(options):
-    # documento = spark.table('%s.mcpr_documento' % options['schema_exadata']).\
-    #     filter('docu_fsdc_dk = 1')
-    documento = spark.sql("from documento").filter('docu_fsdc_dk = 1')
+    documento = spark.sql("from documentos_ativos")
     classe = spark.table('%s.mmps_classe_hierarquia' % options['schema_exadata_aux']).\
         filter("CLDC_DS_HIERARQUIA LIKE 'PROCESSO CRIMINAL%'")
     personagem = spark.table('%s.mcpr_personagem' % options['schema_exadata']).\
@@ -37,7 +43,6 @@ def alerta_dctj(options):
     doc_classe = documento.join(broadcast(classe), documento.DOCU_CLDC_DK == classe.cldc_dk, 'inner')
     doc_personagem = doc_classe.join(personagem, doc_classe.DOCU_DK == personagem.PERS_DOCU_DK, 'inner')
     doc_pessoa = doc_personagem.join(pessoa, doc_personagem.PERS_PESS_DK == pessoa.PESS_DK, 'inner')
-    #doc_mp = doc_pessoa.join(mp, doc_pessoa.PESS_NM_PESSOA == mp.alias, 'inner')
     doc_mp = doc_pessoa.alias('doc_pessoa').join(broadcast(mp.alias('mp')), col('doc_pessoa.PESS_NM_PESSOA') == col('mp.alias'), 'inner')
     doc_item = doc_mp.join(item, doc_mp.DOCU_DK == item.ITEM_DOCU_DK, 'inner')
     doc_movimentacao = doc_item.join(movimentacao, doc_item.ITEM_MOVI_DK == movimentacao.MOVI_DK, 'inner')
@@ -46,17 +51,24 @@ def alerta_dctj(options):
         groupBy(pre_columns).agg({'movi_dt_recebimento_guia': 'max'}).\
         withColumnRenamed('max(movi_dt_recebimento_guia)', 'movi_dt_guia')
     
-    doc_pre_alerta = doc_tribunal.join(item, doc_tribunal.docu_dk == item.ITEM_DOCU_DK, 'left')
-    doc_retorno = doc_pre_alerta.join(
-        movimentacao, 
-        (doc_pre_alerta.ITEM_MOVI_DK == movimentacao.MOVI_DK) 
-            & (doc_pre_alerta.docu_orgi_orga_dk_responsavel == movimentacao.MOVI_ORGA_DK_DESTINO)
-            & (doc_pre_alerta.movi_dt_guia < movimentacao.MOVI_DT_RECEBIMENTO_GUIA), 
+    item_movi = item.join(movimentacao, item.ITEM_MOVI_DK == movimentacao.MOVI_DK, 'inner')
+    doc_retorno = doc_tribunal.join(
+        item_movi,
+        (doc_tribunal.docu_dk == item_movi.ITEM_DOCU_DK)
+            & (doc_tribunal.docu_orgi_orga_dk_responsavel == item_movi.MOVI_ORGA_DK_DESTINO)
+            & (doc_tribunal.movi_dt_guia < item_movi.MOVI_DT_RECEBIMENTO_GUIA),
         'left'
     )
     doc_nao_retornado = doc_retorno.filter('movi_dk is null').\
-        withColumn('dt_fim_prazo', expr("to_timestamp(date_add(movi_dt_guia, 60), 'yyyy-MM-dd HH:mm:ss')")).\
-        withColumn('elapsed', lit(datediff(current_date(), 'dt_fim_prazo')).cast(IntegerType()))
-        #withColumn('dt_fim_prazo', expr('date_add(movi_dt_guia, 60)')).\
+        withColumn('dt_guia_tj', expr("to_timestamp(movi_dt_guia, 'yyyy-MM-dd HH:mm:ss')")).\
+        withColumn('elapsed', lit(datediff(current_date(), 'dt_guia_tj')).cast(IntegerType()))
 
-    return doc_nao_retornado.filter('elapsed > 0').select(columns)
+    resultado = doc_nao_retornado.filter('elapsed > 60')
+    resultado = resultado.withColumn("alrt_sigla",
+        when(resultado.elapsed > 180, "DCTJ2")
+        .otherwise("DCTJ")
+    )
+
+    resultado = resultado.withColumn('alrt_key', uuidsha(*key_columns))
+
+    return resultado.select(columns)

--- a/src/alertas/jobs.py
+++ b/src/alertas/jobs.py
@@ -97,8 +97,8 @@ class AlertaSession:
     ]
 
     alerta_list = {
-        # 'DCTJ': [alerta_dctj],
-        # 'DNTJ': [alerta_dntj],
+        'DCTJ': [alerta_dctj, MGP_TABLE_NAME, COLUMN_ORDER_MGP],
+        'DNTJ': [alerta_dntj, MGP_TABLE_NAME, COLUMN_ORDER_MGP],
         # 'DORD': [alerta_dord],
         'GATE': [alerta_gate, MGP_TABLE_NAME, COLUMN_ORDER_MGP],
         'BDPA': [alerta_bdpa, MGP_TABLE_NAME, COLUMN_ORDER_MGP],


### PR DESCRIPTION
Tanto DNTJ quanto DCTJ estavam com duplicidade causada pela etapa do doc_pre_alerta e doc_retorno, já que o LEFT JOIN com movimentação fazia com que uma linha para cada item (e não para cada documento) fosse gerada, de forma que cada documento aparecia centenas de vezes.
Para corrigir isso, um INNER JOIN entre item e movimentação foi feito primeiro, e em seguida feito o LEFT JOIN de documento com item_movi, garantindo assim que os documentos com colunas NULL por conta do LEFT JOIN só aparecessem uma única vez.

DCTJ foi separado em DCTJ (entre 60 e 180 dias sem resposta) e DCTJ2 (+180 dias sem resposta) por demanda da área de negócio.

Também foi adicionada a coluna de alrt_key, para identificar unicamente cada alerta e habilitar a funcionalidade de dispensa.